### PR TITLE
retrict cpu and ram usage

### DIFF
--- a/BioArchLinux/r-metabma/PKGBUILD
+++ b/BioArchLinux/r-metabma/PKGBUILD
@@ -1,49 +1,39 @@
-# system requirements: GNU make, pandoc (>= 1.12.3), pandoc-citeproc
+# system requirements: GNU make
 # Maintainer: sukanka <su975853527@gmail.com>
 
-_pkgname=rstanarm
-_pkgver=2.21.3
+_pkgname=metaBMA
+_pkgver=0.6.7
 pkgname=r-${_pkgname,,}
 pkgver=${_pkgver//[:-]/.}
 pkgrel=1
-pkgdesc='Bayesian Applied Regression Modeling via Stan'
+pkgdesc='Bayesian Model Averaging for Random and Fixed Effects Meta-Analysis'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"
 license=('GPL')
 depends=(
   r
-  r-bayesplot
   r-bh
-  r-ggplot2
-  r-lme4
-  r-loo
+  r-bridgesampling
+  r-coda
+  r-laplacesdemon
+  r-logspline
+  r-mvtnorm
   r-rcpp
   r-rcppeigen
   r-rcppparallel
   r-rstan
   r-rstantools
-  r-shinystan
   r-stanheaders
-  pandoc
 )
 optdepends=(
-  r-betareg
-  r-biglm
-  r-data.table
-  r-digest
-  r-gridextra
-  r-hsaur3
   r-knitr
-  r-mass
-  r-mgcv
   r-rmarkdown
-  r-roxygen2
-  r-stanheaders
+  r-spelling
   r-testthat
 )
 makedepends=('make')
 source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
-sha256sums=('e9f2d3761b8e4f14a6690beb633b08633cba7269ac8b969aedaa12844d1a32a7')
+sha256sums=('330bccb4b2297bc3a8b7291197c5e978b90b002907f762ede40f2d3e383367da')
 
 build() {
   # restrict the usage of memory and cpu, 1 threads usually consumes 2 GiB memory.

--- a/BioArchLinux/r-metabma/lilac.py
+++ b/BioArchLinux/r-metabma/lilac.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+def pre_build():
+    for line in edit_file('PKGBUILD'):
+        if line.startswith('_pkgver='):
+            line = f'_pkgver={_G.newver}'
+        print(line)
+    update_pkgver_and_pkgrel(_G.newver.replace(':', '.').replace('-', '.'))
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-metabma/lilac.yaml
+++ b/BioArchLinux/r-metabma/lilac.yaml
@@ -1,0 +1,20 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: sukanka
+repo_depends:
+  - r-bh
+  - r-bridgesampling
+  - r-coda
+  - r-laplacesdemon
+  - r-logspline
+  - r-mvtnorm
+  - r-rcpp
+  - r-rcppeigen
+  - r-rcppparallel
+  - r-rstan
+  - r-rstantools
+  - r-stanheaders
+update_on:
+  - regex: metaBMA_([\d._-]+).tar.gz
+    source: regex
+    url: https://cran.r-project.org/package=metaBMA


### PR DESCRIPTION
## Involved packages

 - r-rstanarm, r-metabma

## Involved issue

Close #54

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [x] Provide New Package
- [x] Fix the Packages
  - [x] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
`make` is exported as `make -j5` which uses no more than 10GiB memory. It should be safe now.