### PR TITLE
Fix frf2 and optimze openmx

### DIFF
--- a/BioArchLinux/r-frf2/PKGBUILD
+++ b/BioArchLinux/r-frf2/PKGBUILD
@@ -32,6 +32,5 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  install -Dm644 "${_pkgname}/LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
 }
 # vim:set ts=2 sw=2 et:

--- a/BioArchLinux/r-openmx/PKGBUILD
+++ b/BioArchLinux/r-openmx/PKGBUILD
@@ -46,6 +46,8 @@ source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('65c50ce09f9c006b41b7311ec05eba3ae77926d84fb44e3905905208404826ed')
 
 build() {
+  # restrict the usage of cpu. Usage of RAM is OK.
+  export MAKE="make -j5" 
   R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
 }
 


### PR DESCRIPTION
## Involved packages

 - r-frf2, r-openmx

## Involved issue

None.

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [x] Fix the Packages
  - [x] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
openmx uses too much CPU power, it is now restricted to 5 threads.
frf2 has no license bundled.