### PR TITLE
bump pkgrel as they are buildt for r 4.1

### DIFF
--- a/BioArchLinux/r-abind/PKGBUILD
+++ b/BioArchLinux/r-abind/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=abind
 _pkgver=1.4-5
 pkgname=r-${_pkgname,,}
 pkgver=1.4.5
-pkgrel=2
+pkgrel=3
 pkgdesc='Combine Multidimensional Arrays'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-arm/PKGBUILD
+++ b/BioArchLinux/r-arm/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=arm
 _pkgver=1.12-2
 pkgname=r-${_pkgname,,}
 pkgver=1.12.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Data Analysis Using Regression and Multilevel/Hierarchical Models'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-askpass/PKGBUILD
+++ b/BioArchLinux/r-askpass/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=askpass
 _pkgver=1.1
 pkgname=r-${_pkgname,,}
 pkgver=1.1
-pkgrel=3
+pkgrel=4
 pkgdesc='Safe Password Entry for R, Git, and SSH'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-backports/PKGBUILD
+++ b/BioArchLinux/r-backports/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=backports
 _pkgver=1.4.1
 pkgname=r-${_pkgname,,}
 pkgver=1.4.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Reimplementations of Functions Introduced Since R-3.0.0'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-base64enc/PKGBUILD
+++ b/BioArchLinux/r-base64enc/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=base64enc
 _pkgver=0.1-3
 pkgname=r-${_pkgname,,}
 pkgver=0.1.3
-pkgrel=2
+pkgrel=3
 pkgdesc='Tools for base64 encoding'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-bitops/PKGBUILD
+++ b/BioArchLinux/r-bitops/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=bitops
 _pkgver=1.0-7
 pkgname=r-${_pkgname,,}
 pkgver=1.0.7
-pkgrel=3
+pkgrel=4
 pkgdesc='Bitwise Operations'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-brew/PKGBUILD
+++ b/BioArchLinux/r-brew/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=brew
 _pkgver=1.0-7
 pkgname=r-${_pkgname,,}
 pkgver=1.0.7
-pkgrel=2
+pkgrel=3
 pkgdesc='Templating Framework for Report Generation'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-brio/PKGBUILD
+++ b/BioArchLinux/r-brio/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=brio
 _pkgver=1.1.3
 pkgname=r-${_pkgname,,}
 pkgver=1.1.3
-pkgrel=2
+pkgrel=3
 pkgdesc='Basic R Input Output'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-broom/PKGBUILD
+++ b/BioArchLinux/r-broom/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=broom
 _pkgver=0.8.0
 pkgname=r-${_pkgname,,}
 pkgver=0.8.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Convert Statistical Objects into Tidy Tibbles'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-bslib/PKGBUILD
+++ b/BioArchLinux/r-bslib/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=bslib
 _pkgver=0.3.1
 pkgname=r-${_pkgname,,}
 pkgver=0.3.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Custom 'Bootstrap' 'Sass' Themes for 'shiny' and 'rmarkdown'"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-cachem/PKGBUILD
+++ b/BioArchLinux/r-cachem/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=cachem
 _pkgver=1.0.6
 pkgname=r-${_pkgname,,}
 pkgver=1.0.6
-pkgrel=3
+pkgrel=4
 pkgdesc='Cache R Objects with Automatic Pruning'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-callr/PKGBUILD
+++ b/BioArchLinux/r-callr/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=callr
 _pkgver=3.7.0
 pkgname=r-${_pkgname,,}
 pkgver=3.7.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Call R from R'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-cardata/PKGBUILD
+++ b/BioArchLinux/r-cardata/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=carData
 _pkgver=3.0-5
 pkgname=r-${_pkgname,,}
 pkgver=3.0.5
-pkgrel=2
+pkgrel=3
 pkgdesc='Companion to Applied Regression Data Sets'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-catools/PKGBUILD
+++ b/BioArchLinux/r-catools/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=caTools
 _pkgver=1.18.2
 pkgname=r-${_pkgname,,}
 pkgver=1.18.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Tools: Moving Window Statistics, GIF, Base64, ROC AUC, etc'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-checkmate/PKGBUILD
+++ b/BioArchLinux/r-checkmate/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=checkmate
 _pkgver=2.1.0
 pkgname=r-${_pkgname,,}
 pkgver=2.1.0
-pkgrel=3
+pkgrel=4
 pkgdesc='Fast and Versatile Argument Checks'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-coda/PKGBUILD
+++ b/BioArchLinux/r-coda/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=coda
 _pkgver=0.19-4
 pkgname=r-${_pkgname,,}
 pkgver=0.19.4
-pkgrel=2
+pkgrel=3
 pkgdesc='Output Analysis and Diagnostics for MCMC'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-coin/PKGBUILD
+++ b/BioArchLinux/r-coin/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=coin
 _pkgver=1.4-2
 pkgname=r-${_pkgname,,}
 pkgver=1.4.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Conditional Inference Procedures in a Permutation Test Framework'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-colorspace/PKGBUILD
+++ b/BioArchLinux/r-colorspace/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=colorspace
 _pkgver=2.0-3
 pkgname=r-${_pkgname,,}
 pkgver=2.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc='A Toolbox for Manipulating and Assessing Colors and Palettes'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-colourpicker/PKGBUILD
+++ b/BioArchLinux/r-colourpicker/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=colourpicker
 _pkgver=1.1.1
 pkgname=r-${_pkgname,,}
 pkgver=1.1.1
-pkgrel=2
+pkgrel=3
 pkgdesc='A Colour Picker Tool for Shiny and for Selecting Colours in Plots'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-combinat/PKGBUILD
+++ b/BioArchLinux/r-combinat/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=combinat
 _pkgver=0.0-8
 pkgname=r-${_pkgname,,}
 pkgver=0.0.8
-pkgrel=2
+pkgrel=3
 pkgdesc='combinatorics utilities'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-commonmark/PKGBUILD
+++ b/BioArchLinux/r-commonmark/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=commonmark
 _pkgver=1.8.0
 pkgname=r-${_pkgname,,}
 pkgver=1.8.0
-pkgrel=1
+pkgrel=2
 pkgdesc='High Performance CommonMark and Github Markdown Rendering in R'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-conquer/PKGBUILD
+++ b/BioArchLinux/r-conquer/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=conquer
 _pkgver=1.3.0
 pkgname=r-${_pkgname,,}
 pkgver=1.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Convolution-Type Smoothed Quantile Regression'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-corpcor/PKGBUILD
+++ b/BioArchLinux/r-corpcor/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=corpcor
 _pkgver=1.6.10
 pkgname=r-${_pkgname,,}
 pkgver=1.6.10
-pkgrel=2
+pkgrel=3
 pkgdesc='Efficient Estimation of Covariance and (Partial) Correlation'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-corrplot/PKGBUILD
+++ b/BioArchLinux/r-corrplot/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=corrplot
 _pkgver=0.92
 pkgname=r-${_pkgname,,}
 pkgver=0.92
-pkgrel=2
+pkgrel=3
 pkgdesc='Visualization of a Correlation Matrix'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-cowplot/PKGBUILD
+++ b/BioArchLinux/r-cowplot/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=cowplot
 _pkgver=1.1.1
 pkgname=r-${_pkgname,,}
 pkgver=1.1.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Streamlined Plot Theme and Plot Annotations for 'ggplot2'"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-cpp11/PKGBUILD
+++ b/BioArchLinux/r-cpp11/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=cpp11
 _pkgver=0.4.2
 pkgname=r-${_pkgname,,}
 pkgver=0.4.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A C++11 Interface for R's C Interface"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-crayon/PKGBUILD
+++ b/BioArchLinux/r-crayon/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=crayon
 _pkgver=1.5.1
 pkgname=r-${_pkgname,,}
 pkgver=1.5.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Colored Terminal Output'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-crosstalk/PKGBUILD
+++ b/BioArchLinux/r-crosstalk/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=crosstalk
 _pkgver=1.2.0
 pkgname=r-${_pkgname,,}
 pkgver=1.2.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Inter-Widget Interactivity for HTML Widgets'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-data.table/PKGBUILD
+++ b/BioArchLinux/r-data.table/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=data.table
 _pkgver=1.14.2
 pkgname=r-${_pkgname,,}
 pkgver=1.14.2
-pkgrel=3
+pkgrel=4
 pkgdesc='Extension of `data.frame`'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-dbscan/PKGBUILD
+++ b/BioArchLinux/r-dbscan/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=dbscan
 _pkgver=1.1-10
 pkgname=r-${_pkgname,,}
 pkgver=1.1.10
-pkgrel=1
+pkgrel=2
 pkgdesc='Density Based Clustering of Applications with Noise (DBSCAN) and Related Algorithms'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-deoptimr/PKGBUILD
+++ b/BioArchLinux/r-deoptimr/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=DEoptimR
 _pkgver=1.0-11
 pkgname=r-${_pkgname,,}
 pkgver=1.0.11
-pkgrel=1
+pkgrel=2
 pkgdesc='Differential Evolution Optimization in Pure R'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-deriv/PKGBUILD
+++ b/BioArchLinux/r-deriv/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=Deriv
 _pkgver=4.1.3
 pkgname=r-${_pkgname,,}
 pkgver=4.1.3
-pkgrel=2
+pkgrel=3
 pkgdesc='Symbolic Differentiation'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-desc/PKGBUILD
+++ b/BioArchLinux/r-desc/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=desc
 _pkgver=1.4.1
 pkgname=r-${_pkgname,,}
 pkgver=1.4.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Manipulate DESCRIPTION Files'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-desolve/PKGBUILD
+++ b/BioArchLinux/r-desolve/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=deSolve
 _pkgver=1.32
 pkgname=r-${_pkgname,,}
 pkgver=1.32
-pkgrel=1
+pkgrel=2
 pkgdesc="Solvers for Initial Value Problems of Differential Equations ('ODE', 'DAE', 'DDE')"
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-diffobj/PKGBUILD
+++ b/BioArchLinux/r-diffobj/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=diffobj
 _pkgver=0.3.5
 pkgname=r-${_pkgname,,}
 pkgver=0.3.5
-pkgrel=2
+pkgrel=3
 pkgdesc='Diffs for R Objects'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-digest/PKGBUILD
+++ b/BioArchLinux/r-digest/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=digest
 _pkgver=0.6.29
 pkgname=r-${_pkgname,,}
 pkgver=0.6.29
-pkgrel=3
+pkgrel=4
 pkgdesc='Create Compact Hash Digests of R Objects'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-diptest/PKGBUILD
+++ b/BioArchLinux/r-diptest/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=diptest
 _pkgver=0.76-0
 pkgname=r-${_pkgname,,}
 pkgver=0.76.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Hartigan's Dip Test Statistic for Unimodality - Corrected"
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-distributional/PKGBUILD
+++ b/BioArchLinux/r-distributional/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=distributional
 _pkgver=0.3.0
 pkgname=r-${_pkgname,,}
 pkgver=0.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Vectorised Probability Distributions'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-doparallel/PKGBUILD
+++ b/BioArchLinux/r-doparallel/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=doParallel
 _pkgver=1.0.17
 pkgname=r-${_pkgname,,}
 pkgver=1.0.17
-pkgrel=2
+pkgrel=3
 pkgdesc="Foreach Parallel Adaptor for the 'parallel' Package"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-e1071/PKGBUILD
+++ b/BioArchLinux/r-e1071/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=e1071
 _pkgver=1.7-9
 pkgname=r-${_pkgname,,}
 pkgver=1.7.9
-pkgrel=2
+pkgrel=3
 pkgdesc='Misc Functions of the Department of Statistics, Probability Theory Group (Formerly: E1071), TU Wien'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-ellipse/PKGBUILD
+++ b/BioArchLinux/r-ellipse/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=ellipse
 _pkgver=0.4.2
 pkgname=r-${_pkgname,,}
 pkgver=0.4.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Functions for Drawing Ellipses and Ellipse-Like Confidence Regions'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-ellipsis/PKGBUILD
+++ b/BioArchLinux/r-ellipsis/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=ellipsis
 _pkgver=0.3.2
 pkgname=r-${_pkgname,,}
 pkgver=0.3.2
-pkgrel=3
+pkgrel=4
 pkgdesc='Tools for Working with ...'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-envstats/PKGBUILD
+++ b/BioArchLinux/r-envstats/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=EnvStats
 _pkgver=2.7.0
 pkgname=r-${_pkgname,,}
 pkgver=2.7.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Package for Environmental Statistics, Including US EPA Guidance'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-estimability/PKGBUILD
+++ b/BioArchLinux/r-estimability/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=estimability
 _pkgver=1.3
 pkgname=r-${_pkgname,,}
 pkgver=1.3
-pkgrel=2
+pkgrel=3
 pkgdesc='Tools for Assessing Estimability of Linear Predictions'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-evaluate/PKGBUILD
+++ b/BioArchLinux/r-evaluate/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=evaluate
 _pkgver=0.15
 pkgname=r-${_pkgname,,}
 pkgver=0.15
-pkgrel=1
+pkgrel=2
 pkgdesc='Parsing and Evaluation Tools that Provide More Details than the Default'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-extradistr/PKGBUILD
+++ b/BioArchLinux/r-extradistr/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=extraDistr
 _pkgver=1.9.1
 pkgname=r-${_pkgname,,}
 pkgver=1.9.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Additional Univariate and Multivariate Distributions'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-fansi/PKGBUILD
+++ b/BioArchLinux/r-fansi/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=fansi
 _pkgver=1.0.3
 pkgname=r-${_pkgname,,}
 pkgver=1.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc='ANSI Control Sequence Aware String Functions'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-farver/PKGBUILD
+++ b/BioArchLinux/r-farver/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=farver
 _pkgver=2.1.0
 pkgname=r-${_pkgname,,}
 pkgver=2.1.0
-pkgrel=2
+pkgrel=3
 pkgdesc='High Performance Colour Space Manipulation'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-fastmap/PKGBUILD
+++ b/BioArchLinux/r-fastmap/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=fastmap
 _pkgver=1.1.0
 pkgname=r-${_pkgname,,}
 pkgver=1.1.0
-pkgrel=3
+pkgrel=4
 pkgdesc='Fast Data Structures'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-fdrtool/PKGBUILD
+++ b/BioArchLinux/r-fdrtool/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=fdrtool
 _pkgver=1.2.17
 pkgname=r-${_pkgname,,}
 pkgver=1.2.17
-pkgrel=2
+pkgrel=3
 pkgdesc='Estimation of (Local) False Discovery Rates and Higher Criticism'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-fitdistrplus/PKGBUILD
+++ b/BioArchLinux/r-fitdistrplus/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=fitdistrplus
 _pkgver=1.1-8
 pkgname=r-${_pkgname,,}
 pkgver=1.1.8
-pkgrel=1
+pkgrel=2
 pkgdesc='Help to Fit of a Parametric Distribution to Non-Censored or Censored Data'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-flexmix/PKGBUILD
+++ b/BioArchLinux/r-flexmix/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=flexmix
 _pkgver=2.3-17
 pkgname=r-${_pkgname,,}
 pkgver=2.3.17
-pkgrel=2
+pkgrel=3
 pkgdesc='Flexible Mixture Modeling'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-fontawesome/PKGBUILD
+++ b/BioArchLinux/r-fontawesome/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=fontawesome
 _pkgver=0.2.2
 pkgname=r-${_pkgname,,}
 pkgver=0.2.2
-pkgrel=2
+pkgrel=3
 pkgdesc="Easily Work with 'Font Awesome' Icons"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-forcats/PKGBUILD
+++ b/BioArchLinux/r-forcats/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=forcats
 _pkgver=0.5.1
 pkgname=r-${_pkgname,,}
 pkgver=0.5.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Tools for Working with Categorical Variables (Factors)'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-foreach/PKGBUILD
+++ b/BioArchLinux/r-foreach/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=foreach
 _pkgver=1.5.2
 pkgname=r-${_pkgname,,}
 pkgver=1.5.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Provides Foreach Looping Construct'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-formula/PKGBUILD
+++ b/BioArchLinux/r-formula/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=Formula
 _pkgver=1.2-4
 pkgname=r-${_pkgname,,}
 pkgver=1.2.4
-pkgrel=2
+pkgrel=3
 pkgdesc='Extended Model Formulas'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-fpc/PKGBUILD
+++ b/BioArchLinux/r-fpc/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=fpc
 _pkgver=2.2-9
 pkgname=r-${_pkgname,,}
 pkgver=2.2.9
-pkgrel=2
+pkgrel=3
 pkgdesc='Flexible Procedures for Clustering'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-fs/PKGBUILD
+++ b/BioArchLinux/r-fs/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=fs
 _pkgver=1.5.2
 pkgname=r-${_pkgname,,}
 pkgver=1.5.2
-pkgrel=2
+pkgrel=3
 pkgdesc="Cross-Platform File System Operations Based on 'libuv'"
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-gbm/PKGBUILD
+++ b/BioArchLinux/r-gbm/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=gbm
 _pkgver=2.1.8
 pkgname=r-${_pkgname,,}
 pkgver=2.1.8
-pkgrel=2
+pkgrel=3
 pkgdesc='Generalized Boosted Regression Models'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-gdtools/PKGBUILD
+++ b/BioArchLinux/r-gdtools/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=gdtools
 _pkgver=0.2.4
 pkgname=r-${_pkgname,,}
 pkgver=0.2.4
-pkgrel=1
+pkgrel=2
 pkgdesc='Utilities for Graphical Rendering'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-generics/PKGBUILD
+++ b/BioArchLinux/r-generics/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=generics
 _pkgver=0.1.2
 pkgname=r-${_pkgname,,}
 pkgver=0.1.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Common S3 Generics not Provided by Base R Methods Related to Model Fitting'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-ggalluvial/PKGBUILD
+++ b/BioArchLinux/r-ggalluvial/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=ggalluvial
 _pkgver=0.12.3
 pkgname=r-${_pkgname,,}
 pkgver=0.12.3
-pkgrel=2
+pkgrel=3
 pkgdesc="Alluvial Plots in 'ggplot2'"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-ggally/PKGBUILD
+++ b/BioArchLinux/r-ggally/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=GGally
 _pkgver=2.1.2
 pkgname=r-${_pkgname,,}
 pkgver=2.1.2
-pkgrel=2
+pkgrel=3
 pkgdesc="Extension to 'ggplot2'"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-ggdendro/PKGBUILD
+++ b/BioArchLinux/r-ggdendro/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=ggdendro
 _pkgver=0.1.23
 pkgname=r-${_pkgname,,}
 pkgver=0.1.23
-pkgrel=1
+pkgrel=2
 pkgdesc="Create Dendrograms and Tree Diagrams Using 'ggplot2'"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-ggdist/PKGBUILD
+++ b/BioArchLinux/r-ggdist/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=ggdist
 _pkgver=3.1.1
 pkgname=r-${_pkgname,,}
 pkgver=3.1.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Visualizations of Distributions and Uncertainty'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-ggmcmc/PKGBUILD
+++ b/BioArchLinux/r-ggmcmc/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=ggmcmc
 _pkgver=1.5.1.1
 pkgname=r-${_pkgname,,}
 pkgver=1.5.1.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Tools for Analyzing MCMC Simulations from Bayesian Inference'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-ggnetwork/PKGBUILD
+++ b/BioArchLinux/r-ggnetwork/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=ggnetwork
 _pkgver=0.5.10
 pkgname=r-${_pkgname,,}
 pkgver=0.5.10
-pkgrel=2
+pkgrel=3
 pkgdesc="Geometries to Plot Networks with 'ggplot2'"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-ggpp/PKGBUILD
+++ b/BioArchLinux/r-ggpp/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=ggpp
 _pkgver=0.4.4
 pkgname=r-${_pkgname,,}
 pkgver=0.4.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Grammar Extensions to 'ggplot2'"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-ggrepel/PKGBUILD
+++ b/BioArchLinux/r-ggrepel/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=ggrepel
 _pkgver=0.9.1
 pkgname=r-${_pkgname,,}
 pkgver=0.9.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Automatically Position Non-Overlapping Text Labels with 'ggplot2'"
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-ggridges/PKGBUILD
+++ b/BioArchLinux/r-ggridges/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=ggridges
 _pkgver=0.5.3
 pkgname=r-${_pkgname,,}
 pkgver=0.5.3
-pkgrel=2
+pkgrel=3
 pkgdesc="Ridgeline Plots in 'ggplot2'"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-ggsci/PKGBUILD
+++ b/BioArchLinux/r-ggsci/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=ggsci
 _pkgver=2.9
 pkgname=r-${_pkgname,,}
 pkgver=2.9
-pkgrel=2
+pkgrel=3
 pkgdesc="Scientific Journal and Sci-Fi Themed Color Palettes for 'ggplot2'"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-glasso/PKGBUILD
+++ b/BioArchLinux/r-glasso/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=glasso
 _pkgver=1.11
 pkgname=r-${_pkgname,,}
 pkgver=1.11
-pkgrel=2
+pkgrel=3
 pkgdesc='Graphical Lasso: Estimation of Gaussian Graphical Models'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-glue/PKGBUILD
+++ b/BioArchLinux/r-glue/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=glue
 _pkgver=1.6.2
 pkgname=r-${_pkgname,,}
 pkgver=1.6.2
-pkgrel=1
+pkgrel=2
 pkgdesc='Interpreted String Literals'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-gmp/PKGBUILD
+++ b/BioArchLinux/r-gmp/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=gmp
 _pkgver=0.6-5
 pkgname=r-${_pkgname,,}
 pkgver=0.6.5
-pkgrel=1
+pkgrel=2
 pkgdesc='Multiple Precision Arithmetic'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-goftest/PKGBUILD
+++ b/BioArchLinux/r-goftest/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=goftest
 _pkgver=1.2-3
 pkgname=r-${_pkgname,,}
 pkgver=1.2.3
-pkgrel=2
+pkgrel=3
 pkgdesc='Classical Goodness-of-Fit Tests for Univariate Distributions'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-gower/PKGBUILD
+++ b/BioArchLinux/r-gower/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=gower
 _pkgver=1.0.0
 pkgname=r-${_pkgname,,}
 pkgver=1.0.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Gower's Distance"
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-gridextra/PKGBUILD
+++ b/BioArchLinux/r-gridextra/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=gridExtra
 _pkgver=2.3
 pkgname=r-${_pkgname,,}
 pkgver=2.3
-pkgrel=3
+pkgrel=4
 pkgdesc='Miscellaneous Functions for "Grid" Graphics'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-gridgraphics/PKGBUILD
+++ b/BioArchLinux/r-gridgraphics/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=gridGraphics
 _pkgver=0.5-1
 pkgname=r-${_pkgname,,}
 pkgver=0.5.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Redraw Base Graphics Using 'grid' Graphics"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-gtable/PKGBUILD
+++ b/BioArchLinux/r-gtable/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=gtable
 _pkgver=0.3.0
 pkgname=r-${_pkgname,,}
 pkgver=${_pkgver//[:-]/.}
-pkgrel=1
+pkgrel=2
 pkgdesc="Arrange 'Grobs' in Tables"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-hardhat/PKGBUILD
+++ b/BioArchLinux/r-hardhat/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=hardhat
 _pkgver=0.2.0
 pkgname=r-${_pkgname,,}
 pkgver=0.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Construct Modeling Packages'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-hdinterval/PKGBUILD
+++ b/BioArchLinux/r-hdinterval/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=HDInterval
 _pkgver=0.2.2
 pkgname=r-${_pkgname,,}
 pkgver=0.2.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Highest (Posterior) Density Intervals'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-hexbin/PKGBUILD
+++ b/BioArchLinux/r-hexbin/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=hexbin
 _pkgver=1.28.2
 pkgname=r-${_pkgname,,}
 pkgver=1.28.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Hexagonal Binning Routines'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-highr/PKGBUILD
+++ b/BioArchLinux/r-highr/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=highr
 _pkgver=0.9
 pkgname=r-${_pkgname,,}
 pkgver=0.9
-pkgrel=2
+pkgrel=3
 pkgdesc='Syntax Highlighting for R Source Code'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-hms/PKGBUILD
+++ b/BioArchLinux/r-hms/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=hms
 _pkgver=1.1.1
 pkgname=r-${_pkgname,,}
 pkgver=1.1.1
-pkgrel=3
+pkgrel=4
 pkgdesc='Pretty Time of Day'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-htmltable/PKGBUILD
+++ b/BioArchLinux/r-htmltable/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=htmlTable
 _pkgver=2.4.0
 pkgname=r-${_pkgname,,}
 pkgver=2.4.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Advanced Tables for Markdown/HTML'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-htmltools/PKGBUILD
+++ b/BioArchLinux/r-htmltools/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=htmltools
 _pkgver=0.5.2
 pkgname=r-${_pkgname,,}
 pkgver=0.5.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Tools for HTML'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-htmlwidgets/PKGBUILD
+++ b/BioArchLinux/r-htmlwidgets/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=htmlwidgets
 _pkgver=1.5.4
 pkgname=r-${_pkgname,,}
 pkgver=1.5.4
-pkgrel=2
+pkgrel=3
 pkgdesc='HTML Widgets for R'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-httpuv/PKGBUILD
+++ b/BioArchLinux/r-httpuv/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=httpuv
 _pkgver=1.6.5
 pkgname=r-${_pkgname,,}
 pkgver=1.6.5
-pkgrel=2
+pkgrel=3
 pkgdesc='HTTP and WebSocket Server Library'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-huge/PKGBUILD
+++ b/BioArchLinux/r-huge/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=huge
 _pkgver=1.3.5
 pkgname=r-${_pkgname,,}
 pkgver=1.3.5
-pkgrel=2
+pkgrel=3
 pkgdesc='High-Dimensional Undirected Graph Estimation'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-inline/PKGBUILD
+++ b/BioArchLinux/r-inline/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=inline
 _pkgver=0.3.19
 pkgname=r-${_pkgname,,}
 pkgver=0.3.19
-pkgrel=2
+pkgrel=3
 pkgdesc='Functions to Inline C, C++, Fortran Function Calls from R'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-inum/PKGBUILD
+++ b/BioArchLinux/r-inum/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=inum
 _pkgver=1.0-4
 pkgname=r-${_pkgname,,}
 pkgver=1.0.4
-pkgrel=2
+pkgrel=3
 pkgdesc='Interval and Enum-Type Representation of Vectors'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-ipred/PKGBUILD
+++ b/BioArchLinux/r-ipred/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=ipred
 _pkgver=0.9-12
 pkgname=r-${_pkgname,,}
 pkgver=0.9.12
-pkgrel=2
+pkgrel=3
 pkgdesc='Improved Predictors'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-irr/PKGBUILD
+++ b/BioArchLinux/r-irr/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=irr
 _pkgver=0.84.1
 pkgname=r-${_pkgname,,}
 pkgver=0.84.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Various Coefficients of Interrater Reliability and Agreement'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-isoband/PKGBUILD
+++ b/BioArchLinux/r-isoband/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=isoband
 _pkgver=0.2.5
 pkgname=r-${_pkgname,,}
 pkgver=0.2.5
-pkgrel=2
+pkgrel=3
 pkgdesc='Generate Isolines and Isobands from Regularly Spaced Elevation Grids'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-iterators/PKGBUILD
+++ b/BioArchLinux/r-iterators/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=iterators
 _pkgver=1.0.14
 pkgname=r-${_pkgname,,}
 pkgver=1.0.14
-pkgrel=2
+pkgrel=3
 pkgdesc='Provides Iterator Construct'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-jpeg/PKGBUILD
+++ b/BioArchLinux/r-jpeg/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=jpeg
 _pkgver=0.1-9
 pkgname=r-${_pkgname,,}
 pkgver=0.1.9
-pkgrel=2
+pkgrel=3
 pkgdesc='Read and write JPEG images'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-jquerylib/PKGBUILD
+++ b/BioArchLinux/r-jquerylib/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=jquerylib
 _pkgver=0.1.4
 pkgname=r-${_pkgname,,}
 pkgver=0.1.4
-pkgrel=2
+pkgrel=3
 pkgdesc="Obtain 'jQuery' as an HTML Dependency Object"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-kernlab/PKGBUILD
+++ b/BioArchLinux/r-kernlab/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=kernlab
 _pkgver=0.9-30
 pkgname=r-${_pkgname,,}
 pkgver=0.9.30
-pkgrel=1
+pkgrel=2
 pkgdesc='Kernel-Based Machine Learning Lab'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-kknn/PKGBUILD
+++ b/BioArchLinux/r-kknn/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=kknn
 _pkgver=1.3.1
 pkgname=r-${_pkgname,,}
 pkgver=1.3.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Weighted k-Nearest Neighbors'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-labeling/PKGBUILD
+++ b/BioArchLinux/r-labeling/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=labeling
 _pkgver=0.4.2
 pkgname=r-${_pkgname,,}
 pkgver=0.4.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Axis Labeling'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-later/PKGBUILD
+++ b/BioArchLinux/r-later/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=later
 _pkgver=1.3.0
 pkgname=r-${_pkgname,,}
 pkgver=1.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Utilities for Scheduling Functions to Execute Later with Event Loops'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-latticeextra/PKGBUILD
+++ b/BioArchLinux/r-latticeextra/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=latticeExtra
 _pkgver=0.6-29
 pkgname=r-${_pkgname,,}
 pkgver=0.6.29
-pkgrel=2
+pkgrel=3
 pkgdesc='Extra Graphical Utilities Based on Lattice'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-lava/PKGBUILD
+++ b/BioArchLinux/r-lava/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=lava
 _pkgver=1.6.10
 pkgname=r-${_pkgname,,}
 pkgver=1.6.10
-pkgrel=2
+pkgrel=3
 pkgdesc='Latent Variable Models'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-lazyeval/PKGBUILD
+++ b/BioArchLinux/r-lazyeval/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=lazyeval
 _pkgver=0.2.2
 pkgname=r-${_pkgname,,}
 pkgver=0.2.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Lazy (Non-Standard) Evaluation'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-libcoin/PKGBUILD
+++ b/BioArchLinux/r-libcoin/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=libcoin
 _pkgver=1.0-9
 pkgname=r-${_pkgname,,}
 pkgver=1.0.9
-pkgrel=2
+pkgrel=3
 pkgdesc='Linear Test Statistics for Permutation Inference'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-lifecycle/PKGBUILD
+++ b/BioArchLinux/r-lifecycle/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=lifecycle
 _pkgver=1.0.1
 pkgname=r-${_pkgname,,}
 pkgver=1.0.1
-pkgrel=3
+pkgrel=4
 pkgdesc='Manage the Life Cycle of your Package Functions'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-listenv/PKGBUILD
+++ b/BioArchLinux/r-listenv/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=listenv
 _pkgver=0.8.0
 pkgname=r-${_pkgname,,}
 pkgver=0.8.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Environments Behaving (Almost) as Lists'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-lme4/PKGBUILD
+++ b/BioArchLinux/r-lme4/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=lme4
 _pkgver=1.1-29
 pkgname=r-${_pkgname,,}
 pkgver=1.1.29
-pkgrel=1
+pkgrel=2
 pkgdesc="Linear Mixed-Effects Models using 'Eigen' and S4"
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-lmertest/PKGBUILD
+++ b/BioArchLinux/r-lmertest/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=lmerTest
 _pkgver=3.1-3
 pkgname=r-${_pkgname,,}
 pkgver=3.1.3
-pkgrel=1
+pkgrel=2
 pkgdesc='Tests in Linear Mixed Effects Models'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-lmtest/PKGBUILD
+++ b/BioArchLinux/r-lmtest/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=lmtest
 _pkgver=0.9-40
 pkgname=r-${_pkgname,,}
 pkgver=0.9.40
-pkgrel=1
+pkgrel=2
 pkgdesc='Testing Linear Regression Models'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-loo/PKGBUILD
+++ b/BioArchLinux/r-loo/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=loo
 _pkgver=2.5.1
 pkgname=r-${_pkgname,,}
 pkgver=2.5.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Efficient Leave-One-Out Cross-Validation and WAIC for Bayesian Models'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-lpsolve/PKGBUILD
+++ b/BioArchLinux/r-lpsolve/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=lpSolve
 _pkgver=5.6.15
 pkgname=r-${_pkgname,,}
 pkgver=5.6.15
-pkgrel=2
+pkgrel=3
 pkgdesc="Interface to 'Lp_solve' v. 5.5 to Solve Linear/Integer Programs"
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-lubridate/PKGBUILD
+++ b/BioArchLinux/r-lubridate/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=lubridate
 _pkgver=1.8.0
 pkgname=r-${_pkgname,,}
 pkgver=1.8.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Make Dealing with Dates a Little Easier'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-magrittr/PKGBUILD
+++ b/BioArchLinux/r-magrittr/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=magrittr
 _pkgver=2.0.3
 pkgname=r-${_pkgname,,}
 pkgver=2.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc='A Forward-Pipe Operator for R'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-markdown/PKGBUILD
+++ b/BioArchLinux/r-markdown/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=markdown
 _pkgver=1.1
 pkgname=r-${_pkgname,,}
 pkgver=1.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Render Markdown with the C Library 'Sundown'"
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-mathjaxr/PKGBUILD
+++ b/BioArchLinux/r-mathjaxr/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=mathjaxr
 _pkgver=1.6-0
 pkgname=r-${_pkgname,,}
 pkgver=1.6.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Using 'Mathjax' in Rd Files"
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-matrixmodels/PKGBUILD
+++ b/BioArchLinux/r-matrixmodels/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=MatrixModels
 _pkgver=0.5-0
 pkgname=r-${_pkgname,,}
 pkgver=0.5.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Modelling with Sparse and Dense Matrices'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-mcmc/PKGBUILD
+++ b/BioArchLinux/r-mcmc/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=mcmc
 _pkgver=0.9-7
 pkgname=r-${_pkgname,,}
 pkgver=0.9.7
-pkgrel=2
+pkgrel=3
 pkgdesc='Markov Chain Monte Carlo'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-mcmcpack/PKGBUILD
+++ b/BioArchLinux/r-mcmcpack/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=MCMCpack
 _pkgver=1.6-3
 pkgname=r-${_pkgname,,}
 pkgver=1.6.3
-pkgrel=1
+pkgrel=2
 pkgdesc='Markov Chain Monte Carlo (MCMC) Package'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-mglm/PKGBUILD
+++ b/BioArchLinux/r-mglm/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=MGLM
 _pkgver=0.2.1
 pkgname=r-${_pkgname,,}
 pkgver=0.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Multivariate Response Generalized Linear Models'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-mice/PKGBUILD
+++ b/BioArchLinux/r-mice/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=mice
 _pkgver=3.14.0
 pkgname=r-${_pkgname,,}
 pkgver=3.14.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Multivariate Imputation by Chained Equations'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-mime/PKGBUILD
+++ b/BioArchLinux/r-mime/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=mime
 _pkgver=0.12
 pkgname=r-${_pkgname,,}
 pkgver=0.12
-pkgrel=3
+pkgrel=4
 pkgdesc='Map Filenames to MIME Types'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-miniui/PKGBUILD
+++ b/BioArchLinux/r-miniui/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=miniUI
 _pkgver=0.1.1.1
 pkgname=r-${_pkgname,,}
 pkgver=0.1.1.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Shiny UI Widgets for Small Screens'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-minqa/PKGBUILD
+++ b/BioArchLinux/r-minqa/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=minqa
 _pkgver=1.2.4
 pkgname=r-${_pkgname,,}
 pkgver=1.2.4
-pkgrel=2
+pkgrel=3
 pkgdesc='Derivative-free optimization algorithms by quadratic approximation'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-misc3d/PKGBUILD
+++ b/BioArchLinux/r-misc3d/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=misc3d
 _pkgver=0.9-1
 pkgname=r-${_pkgname,,}
 pkgver=0.9.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Miscellaneous 3D Plots'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-mnormt/PKGBUILD
+++ b/BioArchLinux/r-mnormt/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=mnormt
 _pkgver=2.0.2
 pkgname=r-${_pkgname,,}
 pkgver=2.0.2
-pkgrel=2
+pkgrel=3
 pkgdesc='The Multivariate Normal and t Distributions, and Their Truncated Versions'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-modelmetrics/PKGBUILD
+++ b/BioArchLinux/r-modelmetrics/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=ModelMetrics
 _pkgver=1.2.2.2
 pkgname=r-${_pkgname,,}
 pkgver=1.2.2.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Rapid Calculation of Model Metrics'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-modeltools/PKGBUILD
+++ b/BioArchLinux/r-modeltools/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=modeltools
 _pkgver=0.2-23
 pkgname=r-${_pkgname,,}
 pkgver=0.2.23
-pkgrel=2
+pkgrel=3
 pkgdesc='Tools and Classes for Statistical Models'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-munsell/PKGBUILD
+++ b/BioArchLinux/r-munsell/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=munsell
 _pkgver=0.5.0
 pkgname=r-${_pkgname,,}
 pkgver=0.5.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Utilities for Using Munsell Colours'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-mvtnorm/PKGBUILD
+++ b/BioArchLinux/r-mvtnorm/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=mvtnorm
 _pkgver=1.1-3
 pkgname=r-${_pkgname,,}
 pkgver=1.1.3
-pkgrel=2
+pkgrel=3
 pkgdesc='Multivariate Normal and t Distributions'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-nnls/PKGBUILD
+++ b/BioArchLinux/r-nnls/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=nnls
 _pkgver=1.4
 pkgname=r-${_pkgname,,}
 pkgver=1.4
-pkgrel=2
+pkgrel=3
 pkgdesc='The Lawson-Hanson algorithm for non-negative least squares (NNLS)'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-nortest/PKGBUILD
+++ b/BioArchLinux/r-nortest/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=nortest
 _pkgver=1.0-4
 pkgname=r-${_pkgname,,}
 pkgver=1.0.4
-pkgrel=2
+pkgrel=3
 pkgdesc='Tests for Normality'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-numbers/PKGBUILD
+++ b/BioArchLinux/r-numbers/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=numbers
 _pkgver=0.8-2
 pkgname=r-${_pkgname,,}
 pkgver=0.8.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Number-Theoretic Functions'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-numderiv/PKGBUILD
+++ b/BioArchLinux/r-numderiv/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=numDeriv
 _pkgver=2016.8-1.1
 pkgname=r-${_pkgname,,}
 pkgver=2016.8.1.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Accurate Numerical Derivatives'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-officer/PKGBUILD
+++ b/BioArchLinux/r-officer/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=officer
 _pkgver=0.4.2
 pkgname=r-${_pkgname,,}
 pkgver=0.4.2
-pkgrel=1
+pkgrel=2
 pkgdesc='Manipulation of Microsoft Word and PowerPoint Documents'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-openxlsx/PKGBUILD
+++ b/BioArchLinux/r-openxlsx/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=openxlsx
 _pkgver=4.2.5
 pkgname=r-${_pkgname,,}
 pkgver=4.2.5
-pkgrel=2
+pkgrel=3
 pkgdesc='Read, Write and Edit xlsx Files'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-partykit/PKGBUILD
+++ b/BioArchLinux/r-partykit/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=partykit
 _pkgver=1.2-15
 pkgname=r-${_pkgname,,}
 pkgver=1.2.15
-pkgrel=2
+pkgrel=3
 pkgdesc='A Toolkit for Recursive Partytioning'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-patchwork/PKGBUILD
+++ b/BioArchLinux/r-patchwork/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=patchwork
 _pkgver=1.1.1
 pkgname=r-${_pkgname,,}
 pkgver=1.1.1
-pkgrel=2
+pkgrel=3
 pkgdesc='The Composer of Plots'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-pbapply/PKGBUILD
+++ b/BioArchLinux/r-pbapply/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=pbapply
 _pkgver=1.5-0
 pkgname=r-${_pkgname,,}
 pkgver=1.5.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Adding Progress Bar to '*apply' Functions"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-pbkrtest/PKGBUILD
+++ b/BioArchLinux/r-pbkrtest/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=pbkrtest
 _pkgver=0.5.1
 pkgname=r-${_pkgname,,}
 pkgver=0.5.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Parametric Bootstrap, Kenward-Roger and Satterthwaite Based Methods for Test in Mixed Models'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-pillar/PKGBUILD
+++ b/BioArchLinux/r-pillar/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=pillar
 _pkgver=1.7.0
 pkgname=r-${_pkgname,,}
 pkgver=1.7.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Coloured Formatting for Columns'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-pkgbuild/PKGBUILD
+++ b/BioArchLinux/r-pkgbuild/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=pkgbuild
 _pkgver=1.3.1
 pkgname=r-${_pkgname,,}
 pkgver=1.3.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Find Tools Needed to Build R Packages'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-pkgconfig/PKGBUILD
+++ b/BioArchLinux/r-pkgconfig/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=pkgconfig
 _pkgver=2.0.3
 pkgname=r-${_pkgname,,}
 pkgver=2.0.3
-pkgrel=3
+pkgrel=4
 pkgdesc="Private Configuration for 'R' Packages"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-pkgload/PKGBUILD
+++ b/BioArchLinux/r-pkgload/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=pkgload
 _pkgver=1.2.4
 pkgname=r-${_pkgname,,}
 pkgver=1.2.4
-pkgrel=2
+pkgrel=3
 pkgdesc='Simulate Package Installation and Attach'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-plot3d/PKGBUILD
+++ b/BioArchLinux/r-plot3d/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=plot3D
 _pkgver=1.4
 pkgname=r-${_pkgname,,}
 pkgver=1.4
-pkgrel=1
+pkgrel=2
 pkgdesc='Plotting Multi-Dimensional Data'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-plotrix/PKGBUILD
+++ b/BioArchLinux/r-plotrix/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=plotrix
 _pkgver=3.8-2
 pkgname=r-${_pkgname,,}
 pkgver=3.8.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Various Plotting Functions'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-plyr/PKGBUILD
+++ b/BioArchLinux/r-plyr/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=plyr
 _pkgver=1.8.7
 pkgname=r-${_pkgname,,}
 pkgver=1.8.7
-pkgrel=1
+pkgrel=2
 pkgdesc='Tools for Splitting, Applying and Combining Data'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-png/PKGBUILD
+++ b/BioArchLinux/r-png/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=png
 _pkgver=0.1-7
 pkgname=r-${_pkgname,,}
 pkgver=0.1.7
-pkgrel=3
+pkgrel=4
 pkgdesc='Read and write PNG images'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-polynom/PKGBUILD
+++ b/BioArchLinux/r-polynom/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=polynom
 _pkgver=1.4-1
 pkgname=r-${_pkgname,,}
 pkgver=1.4.1
-pkgrel=1
+pkgrel=2
 pkgdesc='A Collection of Functions to Implement a Class for Univariate Polynomial Manipulations'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-posterior/PKGBUILD
+++ b/BioArchLinux/r-posterior/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=posterior
 _pkgver=1.2.1
 pkgname=r-${_pkgname,,}
 pkgver=1.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Tools for Working with Posterior Distributions'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-ppcor/PKGBUILD
+++ b/BioArchLinux/r-ppcor/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=ppcor
 _pkgver=1.1
 pkgname=r-${_pkgname,,}
 pkgver=1.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Partial and Semi-Partial (Part) Correlation'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-prabclus/PKGBUILD
+++ b/BioArchLinux/r-prabclus/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=prabclus
 _pkgver=2.3-2
 pkgname=r-${_pkgname,,}
 pkgver=2.3.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Functions for Clustering and Testing of Presence-Absence, Abundance and Multilocus Genetic Data'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-praise/PKGBUILD
+++ b/BioArchLinux/r-praise/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=praise
 _pkgver=1.0.0
 pkgname=r-${_pkgname,,}
 pkgver=1.0.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Praise Users'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-prettyunits/PKGBUILD
+++ b/BioArchLinux/r-prettyunits/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=prettyunits
 _pkgver=1.1.1
 pkgname=r-${_pkgname,,}
 pkgver=1.1.1
-pkgrel=3
+pkgrel=4
 pkgdesc='Pretty, Human Readable Formatting of Quantities'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-proc/PKGBUILD
+++ b/BioArchLinux/r-proc/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=pROC
 _pkgver=1.18.0
 pkgname=r-${_pkgname,,}
 pkgver=1.18.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Display and Analyze ROC Curves'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-processx/PKGBUILD
+++ b/BioArchLinux/r-processx/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=processx
 _pkgver=3.5.3
 pkgname=r-${_pkgname,,}
 pkgver=3.5.3
-pkgrel=1
+pkgrel=2
 pkgdesc='Execute and Control System Processes'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-prodlim/PKGBUILD
+++ b/BioArchLinux/r-prodlim/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=prodlim
 _pkgver=2019.11.13
 pkgname=r-${_pkgname,,}
 pkgver=2019.11.13
-pkgrel=2
+pkgrel=3
 pkgdesc='Product-Limit Estimation for Censored Event History Analysis'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-progress/PKGBUILD
+++ b/BioArchLinux/r-progress/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=progress
 _pkgver=1.2.2
 pkgname=r-${_pkgname,,}
 pkgver=1.2.2
-pkgrel=3
+pkgrel=4
 pkgdesc='Terminal Progress Bars'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-progressr/PKGBUILD
+++ b/BioArchLinux/r-progressr/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=progressr
 _pkgver=0.10.0
 pkgname=r-${_pkgname,,}
 pkgver=0.10.0
-pkgrel=2
+pkgrel=3
 pkgdesc='An Inclusive, Unifying API for Progress Updates'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-promises/PKGBUILD
+++ b/BioArchLinux/r-promises/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=promises
 _pkgver=1.2.0.1
 pkgname=r-${_pkgname,,}
 pkgver=1.2.0.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Abstractions for Promise-Based Asynchronous Programming'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-proxy/PKGBUILD
+++ b/BioArchLinux/r-proxy/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=proxy
 _pkgver=0.4-26
 pkgname=r-${_pkgname,,}
 pkgver=0.4.26
-pkgrel=2
+pkgrel=3
 pkgdesc='Distance and Similarity Measures'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-purrr/PKGBUILD
+++ b/BioArchLinux/r-purrr/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=purrr
 _pkgver=0.3.4
 pkgname=r-${_pkgname,,}
 pkgver=0.3.4
-pkgrel=3
+pkgrel=4
 pkgdesc='Functional Programming Tools'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-pwr/PKGBUILD
+++ b/BioArchLinux/r-pwr/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=pwr
 _pkgver=1.3-0
 pkgname=r-${_pkgname,,}
 pkgver=1.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Basic Functions for Power Analysis'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-quadprog/PKGBUILD
+++ b/BioArchLinux/r-quadprog/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=quadprog
 _pkgver=1.5-8
 pkgname=r-${_pkgname,,}
 pkgver=1.5.8
-pkgrel=2
+pkgrel=3
 pkgdesc='Functions to Solve Quadratic Programming Problems'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-qvcalc/PKGBUILD
+++ b/BioArchLinux/r-qvcalc/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=qvcalc
 _pkgver=1.0.2
 pkgname=r-${_pkgname,,}
 pkgver=1.0.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Quasi Variances for Factor Effects in Statistical Models'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-r.matlab/PKGBUILD
+++ b/BioArchLinux/r-r.matlab/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=R.matlab
 _pkgver=3.6.2
 pkgname=r-${_pkgname,,}
 pkgver=3.6.2
-pkgrel=3
+pkgrel=4
 pkgdesc='Read and Write MAT Files and Call MATLAB from Within R'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-r.methodss3/PKGBUILD
+++ b/BioArchLinux/r-r.methodss3/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=R.methodsS3
 _pkgver=1.8.1
 pkgname=r-${_pkgname,,}
 pkgver=1.8.1
-pkgrel=3
+pkgrel=4
 pkgdesc='S3 Methods Simplified'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-r.oo/PKGBUILD
+++ b/BioArchLinux/r-r.oo/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=R.oo
 _pkgver=1.24.0
 pkgname=r-${_pkgname,,}
 pkgver=1.24.0
-pkgrel=3
+pkgrel=4
 pkgdesc='R Object-Oriented Programming with or without References'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-r.utils/PKGBUILD
+++ b/BioArchLinux/r-r.utils/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=R.utils
 _pkgver=2.11.0
 pkgname=r-${_pkgname,,}
 pkgver=2.11.0
-pkgrel=3
+pkgrel=4
 pkgdesc='Various Programming Utilities'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-r6/PKGBUILD
+++ b/BioArchLinux/r-r6/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=R6
 _pkgver=2.5.1
 pkgname=r-${_pkgname,,}
 pkgver=2.5.1
-pkgrel=3
+pkgrel=4
 pkgdesc='Encapsulated Classes with Reference Semantics'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-ragg/PKGBUILD
+++ b/BioArchLinux/r-ragg/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=ragg
 _pkgver=1.2.2
 pkgname=r-${_pkgname,,}
 pkgver=1.2.2
-pkgrel=1
+pkgrel=2
 pkgdesc='Graphic Devices Based on AGG'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-rappdirs/PKGBUILD
+++ b/BioArchLinux/r-rappdirs/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=rappdirs
 _pkgver=0.3.3
 pkgname=r-${_pkgname,,}
 pkgver=0.3.3
-pkgrel=3
+pkgrel=4
 pkgdesc='Application Directories: Determine Where to Save Data, Caches, and Logs'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-rbibutils/PKGBUILD
+++ b/BioArchLinux/r-rbibutils/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=rbibutils
 _pkgver=2.2.8
 pkgname=r-${_pkgname,,}
 pkgver=2.2.8
-pkgrel=1
+pkgrel=2
 pkgdesc="Read 'Bibtex' Files and Convert Between Bibliography Formats"
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-rcolorbrewer/PKGBUILD
+++ b/BioArchLinux/r-rcolorbrewer/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=RColorBrewer
 _pkgver=1.1-3
 pkgname=r-${_pkgname,,}
 pkgver=1.1.3
-pkgrel=1
+pkgrel=2
 pkgdesc='ColorBrewer Palettes'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-rcppeigen/PKGBUILD
+++ b/BioArchLinux/r-rcppeigen/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=RcppEigen
 _pkgver=0.3.3.9.2
 pkgname=r-${_pkgname,,}
 pkgver=0.3.3.9.2
-pkgrel=1
+pkgrel=2
 pkgdesc="'Rcpp' Integration for the 'Eigen' Templated Linear Algebra Library"
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-rdpack/PKGBUILD
+++ b/BioArchLinux/r-rdpack/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=Rdpack
 _pkgver=2.3
 pkgname=r-${_pkgname,,}
 pkgver=2.3
-pkgrel=1
+pkgrel=2
 pkgdesc='Update and Manipulate Rd Documentation Objects'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-recipes/PKGBUILD
+++ b/BioArchLinux/r-recipes/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=recipes
 _pkgver=0.2.0
 pkgname=r-${_pkgname,,}
 pkgver=0.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Preprocessing and Feature Engineering Steps for Modeling'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-relimp/PKGBUILD
+++ b/BioArchLinux/r-relimp/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=relimp
 _pkgver=1.0-5
 pkgname=r-${_pkgname,,}
 pkgver=1.0.5
-pkgrel=2
+pkgrel=3
 pkgdesc='Relative Contribution of Effects in a Regression Model'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-rematch2/PKGBUILD
+++ b/BioArchLinux/r-rematch2/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=rematch2
 _pkgver=2.1.2
 pkgname=r-${_pkgname,,}
 pkgver=2.1.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Tidy Output from Regular Expression Matching'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-remotes/PKGBUILD
+++ b/BioArchLinux/r-remotes/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=remotes
 _pkgver=2.4.2
 pkgname=r-${_pkgname,,}
 pkgver=2.4.2
-pkgrel=2
+pkgrel=3
 pkgdesc="R Package Installation from Remote Repositories, Including 'GitHub'"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-reshape/PKGBUILD
+++ b/BioArchLinux/r-reshape/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=reshape
 _pkgver=0.8.9
 pkgname=r-${_pkgname,,}
 pkgver=0.8.9
-pkgrel=1
+pkgrel=2
 pkgdesc='Flexibly Reshape Data'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-reshape2/PKGBUILD
+++ b/BioArchLinux/r-reshape2/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=reshape2
 _pkgver=1.4.4
 pkgname=r-${_pkgname,,}
 pkgver=1.4.4
-pkgrel=2
+pkgrel=3
 pkgdesc='Flexibly Reshape Data: A Reboot of the Reshape Package'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-rjson/PKGBUILD
+++ b/BioArchLinux/r-rjson/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=rjson
 _pkgver=0.2.21
 pkgname=r-${_pkgname,,}
 pkgver=0.2.21
-pkgrel=2
+pkgrel=3
 pkgdesc='JSON for R'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-rlang/PKGBUILD
+++ b/BioArchLinux/r-rlang/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=rlang
 _pkgver=1.0.2
 pkgname=r-${_pkgname,,}
 pkgver=1.0.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Functions for Base Types and Core R and 'Tidyverse' Features"
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-robustbase/PKGBUILD
+++ b/BioArchLinux/r-robustbase/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=robustbase
 _pkgver=0.95-0
 pkgname=r-${_pkgname,,}
 pkgver=0.95.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Basic Robust Statistics'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-rocr/PKGBUILD
+++ b/BioArchLinux/r-rocr/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=ROCR
 _pkgver=1.0-11
 pkgname=r-${_pkgname,,}
 pkgver=1.0.11
-pkgrel=2
+pkgrel=3
 pkgdesc='Visualizing the Performance of Scoring Classifiers'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-rprojroot/PKGBUILD
+++ b/BioArchLinux/r-rprojroot/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=rprojroot
 _pkgver=2.0.3
 pkgname=r-${_pkgname,,}
 pkgver=2.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc='Finding Files in Project Subdirectories'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-rsm/PKGBUILD
+++ b/BioArchLinux/r-rsm/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=rsm
 _pkgver=2.10.3
 pkgname=r-${_pkgname,,}
 pkgver=2.10.3
-pkgrel=2
+pkgrel=3
 pkgdesc='Response-Surface Analysis'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-rstan/PKGBUILD
+++ b/BioArchLinux/r-rstan/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=rstan
 _pkgver=2.21.5
 pkgname=r-${_pkgname,,}
 pkgver=2.21.5
-pkgrel=1
+pkgrel=2
 pkgdesc='R Interface to Stan'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-rstudioapi/PKGBUILD
+++ b/BioArchLinux/r-rstudioapi/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=rstudioapi
 _pkgver=0.13
 pkgname=r-${_pkgname,,}
 pkgver=0.13
-pkgrel=2
+pkgrel=3
 pkgdesc='Safely Access the RStudio API'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-runit/PKGBUILD
+++ b/BioArchLinux/r-runit/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=RUnit
 _pkgver=0.4.32
 pkgname=r-${_pkgname,,}
 pkgver=0.4.32
-pkgrel=2
+pkgrel=3
 pkgdesc='R Unit Test Framework'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-sandwich/PKGBUILD
+++ b/BioArchLinux/r-sandwich/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=sandwich
 _pkgver=3.0-1
 pkgname=r-${_pkgname,,}
 pkgver=3.0.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Robust Covariance Matrix Estimators'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-sass/PKGBUILD
+++ b/BioArchLinux/r-sass/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=sass
 _pkgver=0.4.1
 pkgname=r-${_pkgname,,}
 pkgver=0.4.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Syntactically Awesome Style Sheets ('Sass')"
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-scales/PKGBUILD
+++ b/BioArchLinux/r-scales/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=scales
 _pkgver=1.2.0
 pkgname=r-${_pkgname,,}
 pkgver=1.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Scale Functions for Visualization'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-scatterplot3d/PKGBUILD
+++ b/BioArchLinux/r-scatterplot3d/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=scatterplot3d
 _pkgver=0.3-41
 pkgname=r-${_pkgname,,}
 pkgver=0.3.41
-pkgrel=2
+pkgrel=3
 pkgdesc='3D Scatter Plot'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-sets/PKGBUILD
+++ b/BioArchLinux/r-sets/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=sets
 _pkgver=1.0-21
 pkgname=r-${_pkgname,,}
 pkgver=1.0.21
-pkgrel=2
+pkgrel=3
 pkgdesc='Sets, Generalized Sets, Customizable Sets and Intervals'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-sfsmisc/PKGBUILD
+++ b/BioArchLinux/r-sfsmisc/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=sfsmisc
 _pkgver=1.1-13
 pkgname=r-${_pkgname,,}
 pkgver=1.1.13
-pkgrel=1
+pkgrel=2
 pkgdesc='Utilities from Seminar fuer Statistik ETH Zurich'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-shape/PKGBUILD
+++ b/BioArchLinux/r-shape/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=shape
 _pkgver=1.4.6
 pkgname=r-${_pkgname,,}
 pkgver=1.4.6
-pkgrel=2
+pkgrel=3
 pkgdesc='Functions for Plotting Graphical Shapes, Colors'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-shiny/PKGBUILD
+++ b/BioArchLinux/r-shiny/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=shiny
 _pkgver=1.7.1
 pkgname=r-${_pkgname,,}
 pkgver=1.7.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Web Application Framework for R'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-shinyjs/PKGBUILD
+++ b/BioArchLinux/r-shinyjs/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=shinyjs
 _pkgver=2.1.0
 pkgname=r-${_pkgname,,}
 pkgver=2.1.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Easily Improve the User Experience of Your Shiny Apps in Seconds'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-shinythemes/PKGBUILD
+++ b/BioArchLinux/r-shinythemes/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=shinythemes
 _pkgver=1.2.0
 pkgname=r-${_pkgname,,}
 pkgver=1.2.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Themes for Shiny'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-signal/PKGBUILD
+++ b/BioArchLinux/r-signal/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=signal
 _pkgver=0.7-7
 pkgname=r-${_pkgname,,}
 pkgver=0.7.7
-pkgrel=2
+pkgrel=3
 pkgdesc='Signal Processing'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-sn/PKGBUILD
+++ b/BioArchLinux/r-sn/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=sn
 _pkgver=2.0.2
 pkgname=r-${_pkgname,,}
 pkgver=2.0.2
-pkgrel=1
+pkgrel=2
 pkgdesc='The Skew-Normal and Related Distributions Such as the Skew-t and the SUN'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-sna/PKGBUILD
+++ b/BioArchLinux/r-sna/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=sna
 _pkgver=2.6
 pkgname=r-${_pkgname,,}
 pkgver=2.6
-pkgrel=2
+pkgrel=3
 pkgdesc='Tools for Social Network Analysis'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-snow/PKGBUILD
+++ b/BioArchLinux/r-snow/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=snow
 _pkgver=0.4-4
 pkgname=r-${_pkgname,,}
 pkgver=0.4.4
-pkgrel=3
+pkgrel=4
 pkgdesc='Simple Network of Workstations'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-sourcetools/PKGBUILD
+++ b/BioArchLinux/r-sourcetools/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=sourcetools
 _pkgver=0.1.7
 pkgname=r-${_pkgname,,}
 pkgver=0.1.7
-pkgrel=2
+pkgrel=3
 pkgdesc='Tools for Reading, Tokenizing and Parsing R Code'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-sparsem/PKGBUILD
+++ b/BioArchLinux/r-sparsem/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=SparseM
 _pkgver=1.81
 pkgname=r-${_pkgname,,}
 pkgver=1.81
-pkgrel=2
+pkgrel=3
 pkgdesc='Sparse Linear Algebra'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-squarem/PKGBUILD
+++ b/BioArchLinux/r-squarem/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=SQUAREM
 _pkgver=2021.1
 pkgname=r-${_pkgname,,}
 pkgver=2021.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Squared Extrapolation Methods for Accelerating EM-Like Monotone Algorithms'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-stanheaders/PKGBUILD
+++ b/BioArchLinux/r-stanheaders/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=StanHeaders
 _pkgver=2.21.0-7
 pkgname=r-${_pkgname,,}
 pkgver=2.21.0.7
-pkgrel=2
+pkgrel=3
 pkgdesc='C++ Header Files for Stan'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-statmod/PKGBUILD
+++ b/BioArchLinux/r-statmod/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=statmod
 _pkgver=1.4.36
 pkgname=r-${_pkgname,,}
 pkgver=1.4.36
-pkgrel=2
+pkgrel=3
 pkgdesc='Statistical Modeling'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-stringr/PKGBUILD
+++ b/BioArchLinux/r-stringr/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=stringr
 _pkgver=1.4.0
 pkgname=r-${_pkgname,,}
 pkgver=1.4.0
-pkgrel=3
+pkgrel=4
 pkgdesc='Simple, Consistent Wrappers for Common String Operations'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-strucchange/PKGBUILD
+++ b/BioArchLinux/r-strucchange/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=strucchange
 _pkgver=1.5-2
 pkgname=r-${_pkgname,,}
 pkgver=1.5.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Testing, Monitoring, and Dating Structural Changes'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-suppdists/PKGBUILD
+++ b/BioArchLinux/r-suppdists/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=SuppDists
 _pkgver=1.1-9.7
 pkgname=r-${_pkgname,,}
 pkgver=1.1.9.7
-pkgrel=2
+pkgrel=3
 pkgdesc='Supplementary Distributions'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-svglite/PKGBUILD
+++ b/BioArchLinux/r-svglite/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=svglite
 _pkgver=2.1.0
 pkgname=r-${_pkgname,,}
 pkgver=2.1.0
-pkgrel=2
+pkgrel=3
 pkgdesc="An 'SVG' Graphics Device"
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-sys/PKGBUILD
+++ b/BioArchLinux/r-sys/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=sys
 _pkgver=3.4
 pkgname=r-${_pkgname,,}
 pkgver=3.4
-pkgrel=3
+pkgrel=4
 pkgdesc='Powerful and Reliable Tools for Running System Commands in R'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-systemfonts/PKGBUILD
+++ b/BioArchLinux/r-systemfonts/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=systemfonts
 _pkgver=1.0.4
 pkgname=r-${_pkgname,,}
 pkgver=1.0.4
-pkgrel=2
+pkgrel=3
 pkgdesc='System Native Font Finding'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-tensora/PKGBUILD
+++ b/BioArchLinux/r-tensora/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=tensorA
 _pkgver=0.36.2
 pkgname=r-${_pkgname,,}
 pkgver=0.36.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Advanced Tensor Arithmetic with Named Indices'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-textshaping/PKGBUILD
+++ b/BioArchLinux/r-textshaping/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=textshaping
 _pkgver=0.3.6
 pkgname=r-${_pkgname,,}
 pkgver=0.3.6
-pkgrel=2
+pkgrel=3
 pkgdesc="Bindings to the 'HarfBuzz' and 'Fribidi' Libraries for Text Shaping"
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-threejs/PKGBUILD
+++ b/BioArchLinux/r-threejs/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=threejs
 _pkgver=0.3.3
 pkgname=r-${_pkgname,,}
 pkgver=0.3.3
-pkgrel=2
+pkgrel=3
 pkgdesc='Interactive 3D Scatter Plots, Networks and Globes'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-tidyr/PKGBUILD
+++ b/BioArchLinux/r-tidyr/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=tidyr
 _pkgver=1.2.0
 pkgname=r-${_pkgname,,}
 pkgver=1.2.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Tidy Messy Data'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-tidyselect/PKGBUILD
+++ b/BioArchLinux/r-tidyselect/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=tidyselect
 _pkgver=1.1.2
 pkgname=r-${_pkgname,,}
 pkgver=1.1.2
-pkgrel=1
+pkgrel=2
 pkgdesc='Select from a Set of Strings'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-timedate/PKGBUILD
+++ b/BioArchLinux/r-timedate/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=timeDate
 _pkgver=3043.102
 pkgname=r-${_pkgname,,}
 pkgver=3043.102
-pkgrel=2
+pkgrel=3
 pkgdesc='Rmetrics - Chronological and Calendar Objects'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-tmvnsim/PKGBUILD
+++ b/BioArchLinux/r-tmvnsim/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=tmvnsim
 _pkgver=1.0-2
 pkgname=r-${_pkgname,,}
 pkgver=1.0.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Truncated Multivariate Normal Simulation'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-truncnorm/PKGBUILD
+++ b/BioArchLinux/r-truncnorm/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=truncnorm
 _pkgver=1.0-8
 pkgname=r-${_pkgname,,}
 pkgver=1.0.8
-pkgrel=2
+pkgrel=3
 pkgdesc='Truncated Normal Distribution'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-ttr/PKGBUILD
+++ b/BioArchLinux/r-ttr/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=TTR
 _pkgver=0.24.3
 pkgname=r-${_pkgname,,}
 pkgver=0.24.3
-pkgrel=2
+pkgrel=3
 pkgdesc='Technical Trading Rules'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-utf8/PKGBUILD
+++ b/BioArchLinux/r-utf8/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=utf8
 _pkgver=1.2.2
 pkgname=r-${_pkgname,,}
 pkgver=1.2.2
-pkgrel=3
+pkgrel=4
 pkgdesc='Unicode Text Processing'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-vcd/PKGBUILD
+++ b/BioArchLinux/r-vcd/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=vcd
 _pkgver=1.4-9
 pkgname=r-${_pkgname,,}
 pkgver=1.4.9
-pkgrel=2
+pkgrel=3
 pkgdesc='Visualizing Categorical Data'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-vctrs/PKGBUILD
+++ b/BioArchLinux/r-vctrs/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=vctrs
 _pkgver=0.4.1
 pkgname=r-${_pkgname,,}
 pkgver=0.4.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Vector Helpers'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-vipor/PKGBUILD
+++ b/BioArchLinux/r-vipor/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=vipor
 _pkgver=0.4.5
 pkgname=r-${_pkgname,,}
 pkgver=0.4.5
-pkgrel=2
+pkgrel=3
 pkgdesc='Plot Categorical Data Using Quasirandom Noise and Density Estimates'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-viridis/PKGBUILD
+++ b/BioArchLinux/r-viridis/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=viridis
 _pkgver=0.6.2
 pkgname=r-${_pkgname,,}
 pkgver=0.6.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Colorblind-Friendly Color Maps for R'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-viridislite/PKGBUILD
+++ b/BioArchLinux/r-viridislite/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=viridisLite
 _pkgver=0.4.0
 pkgname=r-${_pkgname,,}
 pkgver=0.4.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Colorblind-Friendly Color Maps (Lite Version)'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-waldo/PKGBUILD
+++ b/BioArchLinux/r-waldo/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=waldo
 _pkgver=0.4.0
 pkgname=r-${_pkgname,,}
 pkgver=0.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Find Differences Between R Objects'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-withr/PKGBUILD
+++ b/BioArchLinux/r-withr/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=withr
 _pkgver=2.5.0
 pkgname=r-${_pkgname,,}
 pkgver=2.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Run Code 'With' Temporarily Modified Global State"
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-wordcloud/PKGBUILD
+++ b/BioArchLinux/r-wordcloud/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=wordcloud
 _pkgver=2.6
 pkgname=r-${_pkgname,,}
 pkgver=2.6
-pkgrel=2
+pkgrel=3
 pkgdesc='Word Clouds'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-xml/PKGBUILD
+++ b/BioArchLinux/r-xml/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=XML
 _pkgver=3.99-0.9
 pkgname=r-${_pkgname,,}
 pkgver=3.99.0.9
-pkgrel=1
+pkgrel=2
 pkgdesc='Tools for Parsing and Generating XML Within R and S-Plus'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-xml2/PKGBUILD
+++ b/BioArchLinux/r-xml2/PKGBUILD
@@ -5,7 +5,7 @@ _pkgname=xml2
 _pkgver=1.3.3
 pkgname=r-${_pkgname,,}
 pkgver=1.3.3
-pkgrel=3
+pkgrel=4
 pkgdesc='Parse XML'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-xtable/PKGBUILD
+++ b/BioArchLinux/r-xtable/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=xtable
 _pkgver=1.8-4
 pkgname=r-${_pkgname,,}
 pkgver=1.8.4
-pkgrel=2
+pkgrel=3
 pkgdesc='Export Tables to LaTeX or HTML'
 arch=('any')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-xts/PKGBUILD
+++ b/BioArchLinux/r-xts/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=xts
 _pkgver=0.12.1
 pkgname=r-${_pkgname,,}
 pkgver=0.12.1
-pkgrel=2
+pkgrel=3
 pkgdesc='eXtensible Time Series'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-yaml/PKGBUILD
+++ b/BioArchLinux/r-yaml/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=yaml
 _pkgver=2.3.5
 pkgname=r-${_pkgname,,}
 pkgver=2.3.5
-pkgrel=1
+pkgrel=2
 pkgdesc='Methods to Convert R Data to YAML and Back'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"

--- a/BioArchLinux/r-zip/PKGBUILD
+++ b/BioArchLinux/r-zip/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=zip
 _pkgver=2.2.0
 pkgname=r-${_pkgname,,}
 pkgver=2.2.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Cross-Platform 'zip' Compression"
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"


### PR DESCRIPTION
## Involved packages
They are reported by be built against r 4.1 by 
```
temp=installed.packages()
temp=data.frame(temp[,c(1,16)])
temp[order(temp$Built),]
 ```
They are
```
r-abind
r-arm
r-askpass
r-backports
r-base64enc
r-bitops
r-brew
r-brio
r-bslib
r-cachem
r-callr
r-cardata
r-catools
r-coda
r-coin
r-colorspace
r-colourpicker
r-combinat
r-commonmark
r-corpcor
r-corrplot
r-cowplot
r-cpp11
r-crosstalk
r-data.table
r-dbscan
r-deriv
r-desc
r-diffobj
r-digest
r-diptest
r-distributional
r-doparallel
r-e1071
r-ellipse
r-ellipsis
r-envstats
r-estimability
r-evaluate
r-extradistr
r-farver
r-fastmap
r-fdrtool
r-fitdistrplus
r-flexmix
r-fontawesome
r-forcats
r-foreach
r-formula
r-fpc
r-fs
r-gbm
r-gdtools
r-generics
r-ggalluvial
r-ggally
r-ggdendro
r-ggdist
r-ggmcmc
r-ggnetwork
r-ggrepel
r-ggridges
r-ggsci
r-glasso
r-glue
r-goftest
r-gower
r-gridextra
r-gridgraphics
r-gtable
r-hardhat
r-hdinterval
r-hexbin
r-highr
r-hms
r-htmltable
r-htmltools
r-htmlwidgets
r-httpuv
r-huge
r-inline
r-inum
r-ipred
r-irr
r-isoband
r-iterators
r-jpeg
r-jquerylib
r-kknn
r-labeling
r-later
r-latticeextra
r-lava
r-lazyeval
r-libcoin
r-lifecycle
r-listenv
r-lmertest
r-lpsolve
r-lubridate
r-markdown
r-mathjaxr
r-matrixmodels
r-mcmc
r-mice
r-mime
r-miniui
r-minqa
r-misc3d
r-mnormt
r-modelmetrics
r-modeltools
r-munsell
r-mvtnorm
r-nnls
r-nortest
r-numbers
r-numderiv
r-openxlsx
r-partykit
r-patchwork
r-pbapply
r-pbkrtest
r-pillar
r-pkgbuild
r-pkgconfig
r-pkgload
r-plot3d
r-plotrix
r-png
r-posterior
r-ppcor
r-prabclus
r-praise
r-prettyunits
r-proc
r-prodlim
r-progress
r-progressr
r-promises
r-proxy
r-purrr
r-pwr
r-quadprog
r-qvcalc
r-r.matlab
r-r.methodss3
r-r.oo
r-r.utils
r-r6
r-ragg
r-rappdirs
r-recipes
r-relimp
r-rematch2
r-remotes
r-reshape2
r-rjson
r-rlang
r-rocr
r-rsm
r-rstudioapi
r-runit
r-sandwich
r-scatterplot3d
r-sets
r-shape
r-shiny
r-shinyjs
r-shinythemes
r-signal
r-sn
r-sna
r-snow
r-sourcetools
r-sparsem
r-squarem
r-stanheaders
r-statmod
r-stringr
r-strucchange
r-suppdists
r-svglite
r-sys
r-systemfonts
r-tensora
r-textshaping
r-threejs
r-tidyr
r-tidyselect
r-timedate
r-tmvnsim
r-truncnorm
r-ttr
r-utf8
r-vcd
r-vipor
r-viridis
r-viridislite
r-withr
r-wordcloud
r-xml
r-xml2
r-xtable
r-xts
r-yaml
r-zip
r-broom
r-checkmate
r-conquer
r-crayon
r-deoptimr
r-desolve
r-fansi
r-ggpp
r-gmp
r-kernlab
r-lme4
r-lmtest
r-loo
r-magrittr
r-mcmcpack
r-mglm
r-officer
r-plyr
r-polynom
r-processx
r-rbibutils
r-rcolorbrewer
r-rcppeigen
r-rdpack
r-reshape
r-robustbase
r-rprojroot
r-rstan
r-sass
r-scales
r-sfsmisc
r-vctrs
r-waldo
```

## Involved issue

Close #

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [ ] Fix the Packages
  - [ ] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
