### PR TITLE
fix: update url, source and lilac.yaml for pkgs archived in BIOC

### DIFF
--- a/BioArchLinux/r-abaenrichment/PKGBUILD
+++ b/BioArchLinux/r-abaenrichment/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=ABAEnrichment
 _pkgver=1.26.0
 pkgname=r-${_pkgname,,}
 pkgver=1.26.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Gene expression enrichment in human brain regions'
 arch=('x86_64')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r

--- a/BioArchLinux/r-abaenrichment/lilac.yaml
+++ b/BioArchLinux/r-abaenrichment/lilac.yaml
@@ -12,5 +12,5 @@ repo_depends:
 update_on:
 - regex: <td>(\d+.\d+.\d+)</td>
   source: regex
-  url: https://bioconductor.org/packages/ABAEnrichment
+  url: https://bioconductor.org/packages/3.15/ABAEnrichment
 - alias: r

--- a/BioArchLinux/r-autotuner/PKGBUILD
+++ b/BioArchLinux/r-autotuner/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=Autotuner
 _pkgver=1.10.0
 pkgname=r-${_pkgname,,}
 pkgver=1.10.0
-pkgrel=3
+pkgrel=4
 pkgdesc='Automated parameter selection for untargeted metabolomics data processing'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('MIT')
 depends=(
   r

--- a/BioArchLinux/r-autotuner/lilac.yaml
+++ b/BioArchLinux/r-autotuner/lilac.yaml
@@ -13,5 +13,5 @@ repo_depends:
 update_on:
 - regex: <td>(\d+.\d+.\d+)</td>
   source: regex
-  url: https://bioconductor.org/packages/Autotuner
+  url: https://bioconductor.org/packages/3.15/Autotuner
 - alias: r

--- a/BioArchLinux/r-cand/PKGBUILD
+++ b/BioArchLinux/r-cand/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=CAnD
 _pkgver=1.27.0
 pkgname=r-${_pkgname,,}
 pkgver=1.27.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Perform Chromosomal Ancestry Differences (CAnD) Analyses'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('Artistic2.0')
 depends=(
   r
@@ -19,7 +19,7 @@ optdepends=(
   r-biocstyle
   r-runit
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('6bd69498e5248e8c8aa952c838016cad48e22c4fdeea5f628ca1b6b363a9a093')
 
 build() {

--- a/BioArchLinux/r-cand/lilac.yaml
+++ b/BioArchLinux/r-cand/lilac.yaml
@@ -8,5 +8,5 @@ repo_depends:
 update_on:
 - regex: CAnD_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/CAnD
+  url: https://bioconductor.org/packages/3.15/CAnD
 - alias: r

--- a/BioArchLinux/r-caomicsv/PKGBUILD
+++ b/BioArchLinux/r-caomicsv/PKGBUILD
@@ -4,17 +4,17 @@ _pkgname=caOmicsV
 _pkgver=1.25.0
 pkgname=r-${_pkgname,,}
 pkgver=1.25.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Visualization of multi-dimentional cancer genomics data'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
   r-bc3net
   r-igraph
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('5f8fc5982eda405b31aaa8b0f9bb3ed77df42cd62e08ed1d6f5a5718658d2482')
 
 build() {

--- a/BioArchLinux/r-caomicsv/lilac.yaml
+++ b/BioArchLinux/r-caomicsv/lilac.yaml
@@ -8,5 +8,5 @@ repo_depends:
 update_on:
 - regex: caOmicsV_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/caOmicsV
+  url: https://bioconductor.org/packages/3.15/caOmicsV
 - alias: r

--- a/BioArchLinux/r-clonotyper/PKGBUILD
+++ b/BioArchLinux/r-clonotyper/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=clonotypeR
 _pkgver=1.34.0
 pkgname=r-${_pkgname,,}
 pkgver=1.34.0
-pkgrel=2
+pkgrel=3
 pkgdesc='High throughput analysis of T cell antigen receptor sequences'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('custom')
 depends=(
   r
@@ -21,7 +21,7 @@ optdepends=(
   r-runit
   r-vegan
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('d83cf13658ec2119cfddf4b4d88cdd74843a823bba57dd83a596ad219891d696')
 
 build() {

--- a/BioArchLinux/r-clonotyper/lilac.yaml
+++ b/BioArchLinux/r-clonotyper/lilac.yaml
@@ -5,5 +5,5 @@ maintainers:
 update_on:
 - regex: clonotypeR_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/clonotypeR
+  url: https://bioconductor.org/packages/3.15/clonotypeR
 - alias: r

--- a/BioArchLinux/r-countclust/PKGBUILD
+++ b/BioArchLinux/r-countclust/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=CountClust
 _pkgver=1.23.1
 pkgname=r-${_pkgname,,}
 pkgver=1.23.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Clustering and Visualizing RNA-Seq Expression Data using Grade of Membership Models'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r

--- a/BioArchLinux/r-countclust/lilac.yaml
+++ b/BioArchLinux/r-countclust/lilac.yaml
@@ -17,5 +17,5 @@ repo_depends:
 update_on:
 - regex: CountClust_([\d._-]+).zip
   source: regex
-  url: https://bioconductor.org/packages/CountClust
+  url: https://bioconductor.org/packages/3.15/CountClust
 - alias: r

--- a/BioArchLinux/r-ctggem/PKGBUILD
+++ b/BioArchLinux/r-ctggem/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=ctgGEM
 _pkgver=1.7.0
 pkgname=r-${_pkgname,,}
 pkgver=1.7.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Generating Tree Hierarchy Visualizations from Gene Expression Data'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
@@ -28,7 +28,7 @@ optdepends=(
   r-rmarkdown
   r-vgam
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('abb1cc74e7598e646df2a920557ddc0145d0ae068e07cdd7c844806cd2bfaa42')
 
 build() {

--- a/BioArchLinux/r-ctggem/lilac.yaml
+++ b/BioArchLinux/r-ctggem/lilac.yaml
@@ -13,5 +13,5 @@ repo_depends:
 update_on:
 - regex: ctgGEM_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/ctgGEM
+  url: https://bioconductor.org/packages/3.15/ctgGEM
 - alias: r

--- a/BioArchLinux/r-cytotree/PKGBUILD
+++ b/BioArchLinux/r-cytotree/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=CytoTree
 _pkgver=1.6.0
 pkgname=r-${_pkgname,,}
 pkgver=1.6.0
-pkgrel=2
+pkgrel=3
 pkgdesc='A Toolkit for Flow And Mass Cytometry Data'
 arch=('x86_64')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
@@ -42,7 +42,7 @@ optdepends=(
   r-rmarkdown
   r-testthat
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('a8cd66a10de1468d24e620c25d523e643a8508f8db68070ab7cf8e3625874db7')
 
 build() {

--- a/BioArchLinux/r-cytotree/lilac.yaml
+++ b/BioArchLinux/r-cytotree/lilac.yaml
@@ -28,5 +28,5 @@ repo_depends:
 update_on:
 - regex: CytoTree_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/CytoTree
+  url: https://bioconductor.org/packages/3.15/CytoTree
 - alias: r

--- a/BioArchLinux/r-diffloop/PKGBUILD
+++ b/BioArchLinux/r-diffloop/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=diffloop
 _pkgver=1.24.0
 pkgname=r-${_pkgname,,}
 pkgver=1.24.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Identifying differential DNA loops from chromatin topology data'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('MIT')
 depends=(
   r
@@ -41,7 +41,7 @@ optdepends=(
   r-rmarkdown
   r-testthat
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('2f48de52b10b9b59bf31ca50f189939c3c155e14a852d1cb39fc77047c7a126c')
 
 build() {

--- a/BioArchLinux/r-diffloop/lilac.yaml
+++ b/BioArchLinux/r-diffloop/lilac.yaml
@@ -27,5 +27,5 @@ repo_depends:
 update_on:
 - regex: diffloop_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/diffloop
+  url: https://bioconductor.org/packages/3.15/diffloop
 - alias: r

--- a/BioArchLinux/r-enmcb/PKGBUILD
+++ b/BioArchLinux/r-enmcb/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=EnMCB
 _pkgver=1.8.2
 pkgname=r-${_pkgname,,}
 pkgver=1.8.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Predicting Disease Progression Based on Methylation Correlated Blocks using Ensemble Models'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
@@ -34,7 +34,7 @@ optdepends=(
   r-survminer
   r-testthat
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('847b4ad1e11d292f898f5221fc4f54bba9f8d5cf1530be8f54b4969f893ecace')
 
 build() {

--- a/BioArchLinux/r-enmcb/lilac.yaml
+++ b/BioArchLinux/r-enmcb/lilac.yaml
@@ -17,5 +17,5 @@ repo_depends:
 update_on:
 - regex: EnMCB_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/EnMCB
+  url: https://bioconductor.org/packages/3.15/EnMCB
 - alias: r

--- a/BioArchLinux/r-ensemblvep/PKGBUILD
+++ b/BioArchLinux/r-ensemblvep/PKGBUILD
@@ -5,10 +5,10 @@ _pkgname=ensemblVEP
 _pkgver=1.38.0
 pkgname=r-${_pkgname,,}
 pkgver=1.38.0
-pkgrel=2
+pkgrel=3
 pkgdesc='R Interface to Ensembl Variant Effect Predictor'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('Artistic2.0')
 depends=(
   r
@@ -23,7 +23,7 @@ depends=(
 optdepends=(
   r-runit
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('c8ac6f434fe43cfc9bb1d7fe39bd233a4c93b2809dc72bcc736083df9bae94f6')
 
 build() {

--- a/BioArchLinux/r-ensemblvep/lilac.yaml
+++ b/BioArchLinux/r-ensemblvep/lilac.yaml
@@ -13,5 +13,5 @@ repo_depends:
 update_on:
 - regex: ensemblVEP_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/ensemblVEP
+  url: https://bioconductor.org/packages/3.15/ensemblVEP
 - alias: r

--- a/BioArchLinux/r-flowutils/PKGBUILD
+++ b/BioArchLinux/r-flowutils/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=flowUtils
 _pkgver=1.59.0
 pkgname=r-${_pkgname,,}
 pkgver=1.59.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Utilities for flow cytometry'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('Artistic2.0')
 depends=(
   r
@@ -21,7 +21,7 @@ depends=(
 optdepends=(
   r-gatingmldata
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('46d4295df433797feb9b7ce8f285a87b5a08d19a383c8397a6b2a6859b30a387')
 
 build() {

--- a/BioArchLinux/r-flowutils/lilac.yaml
+++ b/BioArchLinux/r-flowutils/lilac.yaml
@@ -12,5 +12,5 @@ repo_depends:
 update_on:
 - regex: flowUtils_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/flowUtils
+  url: https://bioconductor.org/packages/3.15/flowUtils
 - alias: r

--- a/BioArchLinux/r-gaia/PKGBUILD
+++ b/BioArchLinux/r-gaia/PKGBUILD
@@ -4,15 +4,15 @@ _pkgname=gaia
 _pkgver=2.39.0
 pkgname=r-${_pkgname,,}
 pkgver=2.39.0
-pkgrel=2
+pkgrel=3
 pkgdesc='GAIA: An R package for genomic analysis of significant chromosomal aberrations.'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('ea92176588f246094ef4ee7f5957ba3390438d0f8dc6a00e3cd136e39be07508')
 
 build() {

--- a/BioArchLinux/r-gaia/lilac.yaml
+++ b/BioArchLinux/r-gaia/lilac.yaml
@@ -5,5 +5,5 @@ maintainers:
 update_on:
 - regex: gaia_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/gaia
+  url: https://bioconductor.org/packages/3.15/gaia
 - alias: r

--- a/BioArchLinux/r-gapgom/PKGBUILD
+++ b/BioArchLinux/r-gapgom/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=GAPGOM
 _pkgver=1.11.0
 pkgname=r-${_pkgname,,}
 pkgver=1.11.0
-pkgrel=2
+pkgrel=3
 pkgdesc='GAPGOM (novel Gene Annotation Prediction and other GO Metrics)'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('MIT')
 depends=(
   r
@@ -57,7 +57,7 @@ optdepends=(
   r-rmarkdown
   r-testthat
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('df7826b3bc9a7e5063d6b70e4de3ba5d5ddddff6d82bce56cbed93fe0b3f896a')
 
 build() {

--- a/BioArchLinux/r-gapgom/lilac.yaml
+++ b/BioArchLinux/r-gapgom/lilac.yaml
@@ -23,5 +23,5 @@ repo_depends:
 update_on:
 - regex: GAPGOM_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/GAPGOM
+  url: https://bioconductor.org/packages/3.15/GAPGOM
 - alias: r

--- a/BioArchLinux/r-gcsconnection/PKGBUILD
+++ b/BioArchLinux/r-gcsconnection/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=GCSConnection
 _pkgver=1.7.0
 pkgname=r-${_pkgname,,}
 pkgver=1.7.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Creating R Connection with Google Cloud Storage'
 arch=('x86_64')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
@@ -23,7 +23,7 @@ optdepends=(
   r-rmarkdown
   r-testthat
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('ceee2f03534b4e498db7bb4cb4bc9b662540d9d3135ffcd7fe1ef222d0e055df')
 
 build() {

--- a/BioArchLinux/r-gcsconnection/lilac.yaml
+++ b/BioArchLinux/r-gcsconnection/lilac.yaml
@@ -11,5 +11,5 @@ repo_depends:
 update_on:
 - regex: GCSConnection_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/GCSConnection
+  url: https://bioconductor.org/packages/3.15/GCSConnection
 - alias: r

--- a/BioArchLinux/r-gcsfilesystem/PKGBUILD
+++ b/BioArchLinux/r-gcsfilesystem/PKGBUILD
@@ -5,10 +5,10 @@ _pkgname=GCSFilesystem
 _pkgver=1.6.0
 pkgname=r-${_pkgname,,}
 pkgver=1.6.0
-pkgrel=4
+pkgrel=5
 pkgdesc='Mounting a Google Cloud bucket to a local directory'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
@@ -20,7 +20,7 @@ optdepends=(
   r-rmarkdown
   r-testthat
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('cd404d908ba897613ac5d6fcd4988909e6989064f7071c32f1e138039eef6862')
 
 build() {

--- a/BioArchLinux/r-gcsfilesystem/lilac.yaml
+++ b/BioArchLinux/r-gcsfilesystem/lilac.yaml
@@ -5,5 +5,5 @@ maintainers:
 update_on:
 - regex: GCSFilesystem_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/GCSFilesystem
+  url: https://bioconductor.org/packages/3.15/GCSFilesystem
 - alias: r

--- a/BioArchLinux/r-genogam/PKGBUILD
+++ b/BioArchLinux/r-genogam/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=GenoGAM
 _pkgver=2.14.0
 pkgname=r-${_pkgname,,}
 pkgver=2.14.0
-pkgrel=2
+pkgrel=3
 pkgdesc='A GAM based framework for analysis of ChIP-Seq data'
 arch=('x86_64')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r

--- a/BioArchLinux/r-genogam/lilac.yaml
+++ b/BioArchLinux/r-genogam/lilac.yaml
@@ -24,5 +24,5 @@ repo_depends:
 update_on:
 - regex: <td>(\d+.\d+.\d+)</td>
   source: regex
-  url: https://bioconductor.org/packages/GenoGAM
+  url: https://bioconductor.org/packages/3.15/GenoGAM
 - alias: r

--- a/BioArchLinux/r-genphen/PKGBUILD
+++ b/BioArchLinux/r-genphen/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=genphen
 _pkgver=1.24.0
 pkgname=r-${_pkgname,,}
 pkgver=1.24.0
-pkgrel=2
+pkgrel=3
 pkgdesc='genphen: tool for quantification of genotype-phenotype associations in genome wide association studies (GWAS)'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
@@ -30,7 +30,7 @@ optdepends=(
   r-testthat
   r-xtable
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('6805ee931998ad03305a3b56a3356502cb0519cf1bba2f3fe931eece9ec2c0d4')
 
 build() {

--- a/BioArchLinux/r-genphen/lilac.yaml
+++ b/BioArchLinux/r-genphen/lilac.yaml
@@ -14,5 +14,5 @@ repo_depends:
 update_on:
 - regex: genphen_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/genphen
+  url: https://bioconductor.org/packages/3.15/genphen
 - alias: r

--- a/BioArchLinux/r-gpart/PKGBUILD
+++ b/BioArchLinux/r-gpart/PKGBUILD
@@ -5,10 +5,10 @@ _pkgname=gpart
 _pkgver=1.13.0
 pkgname=r-${_pkgname,,}
 pkgver=1.13.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Human genome partitioning of dense sequencing data by identifying haplotype blocks'
 arch=('x86_64')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('MIT')
 depends=(
   r
@@ -32,7 +32,7 @@ optdepends=(
   r-rmarkdown
   r-testthat
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz"
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz"
         "fix_pi.patch")
 sha256sums=('4d8b149f072e10ad1ad149bf09325871cb08d740511bcaef9b4c08aea6e42894'
             '033774f380e8c8edbe056b8dd2b076bcd408895a4ecaa75eb6da5e1c99caae70')

--- a/BioArchLinux/r-gpart/lilac.yaml
+++ b/BioArchLinux/r-gpart/lilac.yaml
@@ -16,5 +16,5 @@ repo_depends:
 update_on:
 - regex: gpart_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/gpart
+  url: https://bioconductor.org/packages/3.15/gpart
 - alias: r

--- a/BioArchLinux/r-gprege/PKGBUILD
+++ b/BioArchLinux/r-gprege/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=gprege
 _pkgver=1.39.0
 pkgname=r-${_pkgname,,}
 pkgver=1.39.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Gaussian Process Ranking and Estimation of Gene Expression time-series'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('AGPL')
 depends=(
   r
@@ -16,7 +16,7 @@ depends=(
 optdepends=(
   r-spam
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('e8a88b04301dc258f87f718b1a74ab707ed7f1566ca8111b3488c9a3cef2d28b')
 
 build() {

--- a/BioArchLinux/r-gprege/lilac.yaml
+++ b/BioArchLinux/r-gprege/lilac.yaml
@@ -7,5 +7,5 @@ repo_depends:
 update_on:
 - regex: gprege_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/gprege
+  url: https://bioconductor.org/packages/3.15/gprege
 - alias: r

--- a/BioArchLinux/r-inversion/PKGBUILD
+++ b/BioArchLinux/r-inversion/PKGBUILD
@@ -4,16 +4,16 @@ _pkgname=inveRsion
 _pkgver=1.43.0
 pkgname=r-${_pkgname,,}
 pkgver=1.43.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Inversions in genotype data'
 arch=('x86_64')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
   r-haplo.stats
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('636acd54444a9fc418469e3e2b3f0f222144f0be8403748e874274e23a085840')
 
 build() {

--- a/BioArchLinux/r-inversion/lilac.yaml
+++ b/BioArchLinux/r-inversion/lilac.yaml
@@ -7,5 +7,5 @@ repo_depends:
 update_on:
 - regex: inveRsion_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/inveRsion
+  url: https://bioconductor.org/packages/3.15/inveRsion
 - alias: r

--- a/BioArchLinux/r-isogenegui/PKGBUILD
+++ b/BioArchLinux/r-isogenegui/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=IsoGeneGUI
 _pkgver=2.31.0
 pkgname=r-${_pkgname,,}
 pkgver=2.31.0
-pkgrel=2
+pkgrel=3
 pkgdesc='A graphical user interface to conduct a dose-response analysis of microarray data'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
@@ -31,7 +31,7 @@ depends=(
 optdepends=(
   r-runit
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('f6f5719df91c062ef1ac9241caf4838d79f717de4175f49064e86756b7eefff0')
 
 build() {

--- a/BioArchLinux/r-isogenegui/lilac.yaml
+++ b/BioArchLinux/r-isogenegui/lilac.yaml
@@ -22,5 +22,5 @@ repo_depends:
 update_on:
 - regex: IsoGeneGUI_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/IsoGeneGUI
+  url: https://bioconductor.org/packages/3.15/IsoGeneGUI
 - alias: r

--- a/BioArchLinux/r-iteremoval/PKGBUILD
+++ b/BioArchLinux/r-iteremoval/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=iteremoval
 _pkgver=1.15.1
 pkgname=r-${_pkgname,,}
 pkgver=1.15.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Iteration removal method for feature selection'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
@@ -20,7 +20,7 @@ optdepends=(
   r-knitr
   r-testthat
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('0218f4fd2bcf4e71df405a78db01a028fa49a8093d6da63cffaab8dd3f45942f')
 
 build() {

--- a/BioArchLinux/r-iteremoval/lilac.yaml
+++ b/BioArchLinux/r-iteremoval/lilac.yaml
@@ -10,5 +10,5 @@ repo_depends:
 update_on:
 - regex: iteremoval_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/iteremoval
+  url: https://bioconductor.org/packages/3.15/iteremoval
 - alias: r

--- a/BioArchLinux/r-macpet/PKGBUILD
+++ b/BioArchLinux/r-macpet/PKGBUILD
@@ -6,10 +6,10 @@ _pkgname=MACPET
 _pkgver=1.15.1
 pkgname=r-${_pkgname,,}
 pkgver=1.15.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Model based analysis for paired-end data'
 arch=('x86_64')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
@@ -45,7 +45,7 @@ optdepends=(
   r-reshape2
   r-rmarkdown
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz"
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz"
         "fix_dbleps.patch")
 sha256sums=('54ff827da7f169b43368d31b6417697ff36a20e464f5fb201de988d7dd88821c'
             '2b22a1d373b9685991d80ea9177e3f085f50c229b995f4ee1be97510fd65632f')

--- a/BioArchLinux/r-macpet/lilac.yaml
+++ b/BioArchLinux/r-macpet/lilac.yaml
@@ -27,5 +27,5 @@ repo_depends:
 update_on:
 - regex: MACPET_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/MACPET
+  url: https://bioconductor.org/packages/3.15/MACPET
 - alias: r

--- a/BioArchLinux/r-mmappr2/PKGBUILD
+++ b/BioArchLinux/r-mmappr2/PKGBUILD
@@ -5,10 +5,10 @@ _pkgname=MMAPPR2
 _pkgver=1.10.0
 pkgname=r-${_pkgname,,}
 pkgver=1.10.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Mutation Mapping Analysis Pipeline for Pooled RNA-Seq'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
@@ -39,7 +39,7 @@ optdepends=(
   r-roxygen2
   r-testthat
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('d9cd249022e557ea7204dd410da4d208201b2aebaf6d1b7f753edd7854960af1')
 
 build() {

--- a/BioArchLinux/r-mmappr2/lilac.yaml
+++ b/BioArchLinux/r-mmappr2/lilac.yaml
@@ -23,5 +23,5 @@ repo_depends:
 update_on:
 - regex: MMAPPR2_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/MMAPPR2
+  url: https://bioconductor.org/packages/3.15/MMAPPR2
 - alias: r

--- a/BioArchLinux/r-networkbma/PKGBUILD
+++ b/BioArchLinux/r-networkbma/PKGBUILD
@@ -6,10 +6,10 @@ _pkgname=networkBMA
 _pkgver=2.35.0
 pkgname=r-${_pkgname,,}
 pkgver=2.35.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Regression-based network inference using Bayesian Model Averaging'
 arch=('x86_64')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
@@ -24,7 +24,7 @@ depends=(
 makedepends=(
   patch
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz"
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz"
         "fix_boostinc.patch")
 sha256sums=('a29156b5bcc82d61f512436a96d29d6518a7042a684c3cd335795d754e5a4075'
             'fe3b4f88661542b0053dc01af9755514e1f889166a68dd1735df29d7e459cfbf')

--- a/BioArchLinux/r-networkbma/lilac.yaml
+++ b/BioArchLinux/r-networkbma/lilac.yaml
@@ -12,5 +12,5 @@ repo_depends:
 update_on:
 - regex: networkBMA_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/networkBMA
+  url: https://bioconductor.org/packages/3.15/networkBMA
 - alias: r

--- a/BioArchLinux/r-onassis/PKGBUILD
+++ b/BioArchLinux/r-onassis/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=Onassis
 _pkgver=1.18.0
 pkgname=r-${_pkgname,,}
 pkgver=1.18.0
-pkgrel=2
+pkgrel=3
 pkgdesc='OnASSIs Ontology Annotation and Semantic SImilarity software'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r

--- a/BioArchLinux/r-onassis/lilac.yaml
+++ b/BioArchLinux/r-onassis/lilac.yaml
@@ -20,6 +20,6 @@ repo_depends:
 update_on:
 - regex: <td>(\d+.\d+.\d+)</td>
   source: regex
-  url: https://bioconductor.org/packages/Onassis
+  url: https://bioconductor.org/packages/3.15/Onassis
 - alias: r
 pre_build: vcs_update

--- a/BioArchLinux/r-perturbatr/PKGBUILD
+++ b/BioArchLinux/r-perturbatr/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=perturbatr
 _pkgver=1.16.0
 pkgname=r-${_pkgname,,}
 pkgver=1.16.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Statistical Analysis of High-Throughput Genetic Perturbation Screens'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r

--- a/BioArchLinux/r-perturbatr/lilac.yaml
+++ b/BioArchLinux/r-perturbatr/lilac.yaml
@@ -21,5 +21,5 @@ repo_depends:
 update_on:
 - regex: <td>(\d+.\d+.\d+)</td>
   source: regex
-  url: https://bioconductor.org/packages/perturbatr
+  url: https://bioconductor.org/packages/3.15/perturbatr
 - alias: r

--- a/BioArchLinux/r-ppistats/PKGBUILD
+++ b/BioArchLinux/r-ppistats/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=ppiStats
 _pkgver=1.62.0
 pkgname=r-${_pkgname,,}
 pkgver=1.62.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Protein-Protein Interaction Statistical Package'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('Artistic2.0')
 depends=(
   r
@@ -22,7 +22,7 @@ optdepends=(
   r-xtable
   r-yeastexpdata
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('01a9a0f95d0abb2d32d28bf064eb08a087cebc89c8ba2239e9a07801959baf70')
 
 build() {

--- a/BioArchLinux/r-ppistats/lilac.yaml
+++ b/BioArchLinux/r-ppistats/lilac.yaml
@@ -10,5 +10,5 @@ repo_depends:
 update_on:
 - regex: ppiStats_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/ppiStats
+  url: https://bioconductor.org/packages/3.15/ppiStats
 - alias: r

--- a/BioArchLinux/r-precisiontrialdrawer/PKGBUILD
+++ b/BioArchLinux/r-precisiontrialdrawer/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=PrecisionTrialDrawer
 _pkgver=1.11.0
 pkgname=r-${_pkgname,,}
 pkgver=1.11.0
-pkgrel=2
+pkgrel=3
 pkgdesc='A Tool to Analyze and Design NGS Based Custom Gene Panels'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
@@ -41,7 +41,7 @@ optdepends=(
   r-knitr
   r-rmarkdown
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('4cc451d5fb6c6aeda70a345421c77d2606f1d23446bfd94eda3dd81f64463cd6')
 
 build() {

--- a/BioArchLinux/r-precisiontrialdrawer/lilac.yaml
+++ b/BioArchLinux/r-precisiontrialdrawer/lilac.yaml
@@ -29,5 +29,5 @@ repo_depends:
 update_on:
 - regex: PrecisionTrialDrawer_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/PrecisionTrialDrawer
+  url: https://bioconductor.org/packages/3.15/PrecisionTrialDrawer
 - alias: r

--- a/BioArchLinux/r-proteomicsannotationhubdata/PKGBUILD
+++ b/BioArchLinux/r-proteomicsannotationhubdata/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=ProteomicsAnnotationHubData
 _pkgver=1.26.0
 pkgname=r-${_pkgname,,}
 pkgver=1.26.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Transform public proteomics data resources into Bioconductor Data Structures'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('Artistic2.0')
 depends=(
   r

--- a/BioArchLinux/r-proteomicsannotationhubdata/lilac.yaml
+++ b/BioArchLinux/r-proteomicsannotationhubdata/lilac.yaml
@@ -15,5 +15,5 @@ repo_depends:
 update_on:
 - regex: <td>(\d+.\d+.\d+)</td>
   source: regex
-  url: https://bioconductor.org/packages/ProteomicsAnnotationHubData
+  url: https://bioconductor.org/packages/3.15/ProteomicsAnnotationHubData
 - alias: r

--- a/BioArchLinux/r-psicquic/PKGBUILD
+++ b/BioArchLinux/r-psicquic/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=PSICQUIC
 _pkgver=1.34.0
 pkgname=r-${_pkgname,,}
 pkgver=1.34.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Proteomics Standard Initiative Common QUery InterfaCe'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('Apache')
 depends=(
   r
@@ -21,7 +21,7 @@ depends=(
 optdepends=(
   r-org.hs.eg.db
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('fd3146e664239fa05413de434774fafe4587b5aac1722c928dec28c156ef733e')
 
 build() {

--- a/BioArchLinux/r-psicquic/lilac.yaml
+++ b/BioArchLinux/r-psicquic/lilac.yaml
@@ -12,5 +12,5 @@ repo_depends:
 update_on:
 - regex: PSICQUIC_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/PSICQUIC
+  url: https://bioconductor.org/packages/3.15/PSICQUIC
 - alias: r

--- a/BioArchLinux/r-pubscore/PKGBUILD
+++ b/BioArchLinux/r-pubscore/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=PubScore
 _pkgver=1.8.0
 pkgname=r-${_pkgname,,}
 pkgver=1.8.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Automatic calculation of literature relevance of genes'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('MIT')
 depends=(
   r
@@ -32,7 +32,7 @@ optdepends=(
   r-summarizedexperiment
   r-testthat
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('0d7908ba4121cea855893e2b5945272c97b889c049c49304a42df76af6fe75a1')
 
 build() {

--- a/BioArchLinux/r-pubscore/lilac.yaml
+++ b/BioArchLinux/r-pubscore/lilac.yaml
@@ -15,5 +15,5 @@ repo_depends:
 update_on:
 - regex: PubScore_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/PubScore
+  url: https://bioconductor.org/packages/3.15/PubScore
 - alias: r

--- a/BioArchLinux/r-pulsedsilac/PKGBUILD
+++ b/BioArchLinux/r-pulsedsilac/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=pulsedSilac
 _pkgver=1.9.1
 pkgname=r-${_pkgname,,}
 pkgver=1.9.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Analysis of pulsed-SILAC quantitative proteomics data'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
@@ -28,7 +28,7 @@ optdepends=(
   r-rmarkdown
   r-testthat
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('8b4a5597eaf54181566e0ff3d6bf5d72d81e71583c6fa7abcd2c1398f4ef68fd')
 
 build() {

--- a/BioArchLinux/r-pulsedsilac/lilac.yaml
+++ b/BioArchLinux/r-pulsedsilac/lilac.yaml
@@ -16,5 +16,5 @@ repo_depends:
 update_on:
 - regex: pulsedSilac_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/pulsedSilac
+  url: https://bioconductor.org/packages/3.15/pulsedSilac
 - alias: r

--- a/BioArchLinux/r-rgin/PKGBUILD
+++ b/BioArchLinux/r-rgin/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=Rgin
 _pkgver=1.15.0
 pkgname=r-${_pkgname,,}
 pkgver=1.15.0
-pkgrel=2
+pkgrel=3
 pkgdesc='gin in R'
 arch=('x86_64')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('MIT')
 depends=(
   r
@@ -18,7 +18,7 @@ optdepends=(
   r-knitr
   r-rmarkdown
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('6ae18bf9e748671366ad65c3de03552da49db4cff6ba08601759ef5c9a90bff4')
 
 prepare() {

--- a/BioArchLinux/r-rgin/lilac.yaml
+++ b/BioArchLinux/r-rgin/lilac.yaml
@@ -8,5 +8,5 @@ repo_depends:
 update_on:
 - regex: Rgin_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/Rgin
+  url: https://bioconductor.org/packages/3.15/Rgin
 - alias: r

--- a/BioArchLinux/r-rmir/PKGBUILD
+++ b/BioArchLinux/r-rmir/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=RmiR
 _pkgver=1.52.0
 pkgname=r-${_pkgname,,}
 pkgver=1.52.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Package to work with miRNAs and miRNA targets with R'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('Artistic2.0')
 depends=(
   r

--- a/BioArchLinux/r-rmir/lilac.yaml
+++ b/BioArchLinux/r-rmir/lilac.yaml
@@ -9,5 +9,5 @@ repo_depends:
 update_on:
 - regex: <td>(\d+.\d+.\d+)</td>
   source: regex
-  url: https://bioconductor.org/packages/RmiR
+  url: https://bioconductor.org/packages/3.15/RmiR
 - alias: r

--- a/BioArchLinux/r-rnits/PKGBUILD
+++ b/BioArchLinux/r-rnits/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=Rnits
 _pkgver=1.29.0
 pkgname=r-${_pkgname,,}
 pkgver=1.29.0
-pkgrel=2
+pkgrel=3
 pkgdesc='R Normalization and Inference of Time Series data'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
@@ -25,7 +25,7 @@ optdepends=(
   r-knitr
   r-stringr
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('d034d60c8924200e662073c9e65fcd162b3d8af3ffd8f96cb55e9f9b5874ca54')
 
 build() {

--- a/BioArchLinux/r-rnits/lilac.yaml
+++ b/BioArchLinux/r-rnits/lilac.yaml
@@ -13,5 +13,5 @@ repo_depends:
 update_on:
 - regex: Rnits_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/Rnits
+  url: https://bioconductor.org/packages/3.15/Rnits
 - alias: r

--- a/BioArchLinux/r-rpsixml/PKGBUILD
+++ b/BioArchLinux/r-rpsixml/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=RpsiXML
 _pkgver=2.38.0
 pkgname=r-${_pkgname,,}
 pkgver=2.38.0
-pkgrel=2
+pkgrel=3
 pkgdesc='R interface to PSI-MI 2.5 files'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('LGPL')
 depends=(
   r
@@ -30,7 +30,7 @@ optdepends=(
   r-scisi
   r-testthat
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('719df8cadff4d9133cde3cd9a7577318673f869452c6e7088e9768dd09bc9674')
 
 build() {

--- a/BioArchLinux/r-rpsixml/lilac.yaml
+++ b/BioArchLinux/r-rpsixml/lilac.yaml
@@ -13,5 +13,5 @@ repo_depends:
 update_on:
 - regex: RpsiXML_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/RpsiXML
+  url: https://bioconductor.org/packages/3.15/RpsiXML
 - alias: r

--- a/BioArchLinux/r-scisi/PKGBUILD
+++ b/BioArchLinux/r-scisi/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=ScISI
 _pkgver=1.68.0
 pkgname=r-${_pkgname,,}
 pkgver=1.68.0
-pkgrel=2
+pkgrel=3
 pkgdesc='In Silico Interactome'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('LGPL')
 depends=(
   r

--- a/BioArchLinux/r-scisi/lilac.yaml
+++ b/BioArchLinux/r-scisi/lilac.yaml
@@ -12,5 +12,5 @@ repo_depends:
 update_on:
 - regex: <td>(\d+.\d+.\d+)</td>
   source: regex
-  url: https://bioconductor.org/packages/ScISI
+  url: https://bioconductor.org/packages/3.15/ScISI
 - alias: r

--- a/BioArchLinux/r-slgi/PKGBUILD
+++ b/BioArchLinux/r-slgi/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=SLGI
 _pkgver=1.56.0
 pkgname=r-${_pkgname,,}
 pkgver=1.56.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Synthetic Lethal Genetic Interaction'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('Artistic2.0')
 depends=(
   r

--- a/BioArchLinux/r-slgi/lilac.yaml
+++ b/BioArchLinux/r-slgi/lilac.yaml
@@ -11,5 +11,5 @@ repo_depends:
 update_on:
 - regex: <td>(\d+.\d+.\d+)</td>
   source: regex
-  url: https://bioconductor.org/packages/SLGI
+  url: https://bioconductor.org/packages/3.15/SLGI
 - alias: r

--- a/BioArchLinux/r-sushi/PKGBUILD
+++ b/BioArchLinux/r-sushi/PKGBUILD
@@ -4,17 +4,17 @@ _pkgname=Sushi
 _pkgver=1.34.0
 pkgname=r-${_pkgname,,}
 pkgver=1.34.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Tools for visualizing genomics data'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
   r-biomart
   r-zoo
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('7804a420ba9d4acfb5fdfbaafe49dba50433f3e4d79b82878779a4f657e6ba29')
 
 build() {

--- a/BioArchLinux/r-sushi/lilac.yaml
+++ b/BioArchLinux/r-sushi/lilac.yaml
@@ -8,5 +8,5 @@ repo_depends:
 update_on:
 - regex: Sushi_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/Sushi
+  url: https://bioconductor.org/packages/3.15/Sushi
 - alias: r

--- a/BioArchLinux/r-timeseriesexperiment/PKGBUILD
+++ b/BioArchLinux/r-timeseriesexperiment/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=TimeSeriesExperiment
 _pkgver=1.13.0
 pkgname=r-${_pkgname,,}
 pkgver=1.13.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Analysis for short time-series data'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('MIT')
 depends=(
   r
@@ -43,7 +43,7 @@ optdepends=(
   r-rmarkdown
   r-upsetr
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('4cb8c6dedf67dc4571f7e4760f05df83b8348508dd2d85457a0da77172efb72d')
 
 build() {

--- a/BioArchLinux/r-timeseriesexperiment/lilac.yaml
+++ b/BioArchLinux/r-timeseriesexperiment/lilac.yaml
@@ -21,5 +21,5 @@ repo_depends:
 update_on:
 - regex: TimeSeriesExperiment_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/TimeSeriesExperiment
+  url: https://bioconductor.org/packages/3.15/TimeSeriesExperiment
 - alias: r

--- a/BioArchLinux/r-tofsims/PKGBUILD
+++ b/BioArchLinux/r-tofsims/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=tofsims
 _pkgver=1.24.0
 pkgname=r-${_pkgname,,}
 pkgver=1.24.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Import, process and analysis of Time-of-Flight Secondary Ion Mass Spectrometry (ToF-SIMS) imaging data'
 arch=('x86_64')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r

--- a/BioArchLinux/r-tofsims/lilac.yaml
+++ b/BioArchLinux/r-tofsims/lilac.yaml
@@ -12,5 +12,5 @@ repo_depends:
 update_on:
 - regex: <td>(\d+.\d+.\d+)</td>
   source: regex
-  url: https://bioconductor.org/packages/tofsims
+  url: https://bioconductor.org/packages/3.15/tofsims
 - alias: r

--- a/BioArchLinux/r-tspair/PKGBUILD
+++ b/BioArchLinux/r-tspair/PKGBUILD
@@ -4,16 +4,16 @@ _pkgname=tspair
 _pkgver=1.53.0
 pkgname=r-${_pkgname,,}
 pkgver=1.53.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Top Scoring Pairs for Microarray Classification'
 arch=('x86_64')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r
   r-biobase
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('b3a00f4f49371e46b138a728d5430f4fb0084dd7816e3418b4d3d61146cdbd13')
 
 build() {

--- a/BioArchLinux/r-tspair/lilac.yaml
+++ b/BioArchLinux/r-tspair/lilac.yaml
@@ -7,5 +7,5 @@ repo_depends:
 update_on:
 - regex: tspair_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/tspair
+  url: https://bioconductor.org/packages/3.15/tspair
 - alias: r

--- a/BioArchLinux/r-tsrchitect/PKGBUILD
+++ b/BioArchLinux/r-tsrchitect/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=TSRchitect
 _pkgver=1.22.0
 pkgname=r-${_pkgname,,}
 pkgver=1.22.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Promoter identification from large-scale TSS profiling data'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('GPL')
 depends=(
   r

--- a/BioArchLinux/r-tsrchitect/lilac.yaml
+++ b/BioArchLinux/r-tsrchitect/lilac.yaml
@@ -20,5 +20,5 @@ repo_depends:
 update_on:
 - regex: <td>(\d+.\d+.\d+)</td>
   source: regex
-  url: https://bioconductor.org/packages/TSRchitect
+  url: https://bioconductor.org/packages/3.15/TSRchitect
 - alias: r

--- a/BioArchLinux/r-tvtb/PKGBUILD
+++ b/BioArchLinux/r-tvtb/PKGBUILD
@@ -4,10 +4,10 @@ _pkgname=TVTB
 _pkgver=1.22.0
 pkgname=r-${_pkgname,,}
 pkgver=1.22.0
-pkgrel=2
+pkgrel=3
 pkgdesc='TVTB: The VCF Tool Box'
 arch=('any')
-url="https://bioconductor.org/packages/${_pkgname}"
+url="https://bioconductor.org/packages/3.15/${_pkgname}"
 license=('Artistic2.0')
 depends=(
   r
@@ -42,7 +42,7 @@ optdepends=(
   r-shiny
   r-testthat
 )
-source=("https://bioconductor.org/packages/release/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+source=("https://bioconductor.org/packages/3.15/bioc/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 sha256sums=('1af5da609ec7b34cc10f5fe898bebf786f4fac573044fee992c86fe15df4dd00')
 
 build() {

--- a/BioArchLinux/r-tvtb/lilac.yaml
+++ b/BioArchLinux/r-tvtb/lilac.yaml
@@ -24,5 +24,5 @@ repo_depends:
 update_on:
 - regex: TVTB_([\d._-]+).tar.gz
   source: regex
-  url: https://bioconductor.org/packages/TVTB
+  url: https://bioconductor.org/packages/3.15/TVTB
 - alias: r


### PR DESCRIPTION
## Involved packages

 - Packages_Name

- r-isogenegui
- r-enmcb
- r-genphen
- r-countclust
- r-rgin
- r-ensemblvep
- r-networkbma
- r-tofsims
- r-perturbatr
- r-gcsconnection
- r-gpart
- r-pulsedsilac
- r-scisi
- r-gaia
- r-gprege
- r-tvtb
- r-diffloop
- r-ppistats
- r-onassis
- r-rnits
- r-tsrchitect
- r-abaenrichment
- r-psicquic
- r-precisiontrialdrawer
- r-ctggem
- r-timeseriesexperiment
- r-cytotree
- r-caomicsv
- r-iteremoval
- r-proteomicsannotationhubdata
- r-inversion
- r-cand
- r-flowutils
- r-slgi
- r-sushi
- r-pubscore
- r-mmappr2
- r-macpet
- r-tspair
- r-clonotyper
- r-gapgom
- r-rmir
- r-genogam
- r-autotuner
- r-rpsixml
- r-gcsfilesystem


Close #

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [x] Fix the Packages
  - [x] PKGBUILD
  - [x] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
