### PR TITLE
Add python-scikit-learn-extra & some more deps for #107

### DIFF
--- a/BioArchLinux/python-grid-strategy/PKGBUILD
+++ b/BioArchLinux/python-grid-strategy/PKGBUILD
@@ -1,0 +1,35 @@
+# Maintainer: Bipin Kumar <bipin@ccmb.res.in>
+
+pkgname=python-grid-strategy
+_module=${pkgname#python-}
+pkgver=0.0.1
+pkgrel=1
+pkgdesc='Organize matplotlib plots using different grid strategies'
+arch=('any')
+url="https://github.com/matplotlib/grid-strategy"
+license=('Apache')
+depends=(
+        'python'
+        'python-numpy'
+        'python-matplotlib'
+        )
+makedepends=(
+            'python-build'
+            'python-installer'
+            'python-wheel'
+            'python-setuptools-scm'
+            )
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_module::1}/$_module/$_module-$pkgver.tar.gz")
+sha256sums=('d8db1c12e6f33eb55ba56a5b19f4848aae862a9a343fea422a353c46ab6ccc23')
+
+build() {
+    cd "$_module-$pkgver"
+    python setup.py build
+}
+
+package() {
+    cd "$_module-$pkgver"
+    python -m installer --destdir="$pkgdir" dist/*.whl
+    install -Dm644 "$srcdir/$_module-$pkgver/LICENSE" -t "$pkgdir/usr/share/licenses/$pkgname"
+}

--- a/BioArchLinux/python-grid-strategy/lilac.yaml
+++ b/BioArchLinux/python-grid-strategy/lilac.yaml
@@ -1,0 +1,15 @@
+maintainers:
+  - github: kbipinkumar
+    email: bipin@ccmb.res.in
+build_prefix: extra-x86_64
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+  run_cmd(['updpkgsums'])
+post_build_script: |
+  git_add_files('PKGBUILD')
+  git_commit()
+  update_aur_repo()
+update_on:
+  - source: pypi
+    pypi: grid-strategy
+  - alias: python

--- a/BioArchLinux/python-oldest-supported-numpy/PKGBUILD
+++ b/BioArchLinux/python-oldest-supported-numpy/PKGBUILD
@@ -1,0 +1,44 @@
+# Imported from AUR
+# Maintainer: Astro Benzene <universebenzene at sina dot com>
+
+pkgname=python-oldest-supported-numpy
+_pyname=${pkgname#python-}
+pkgver=2022.11.19
+pkgrel=1
+pkgdesc="Meta-package providing oldest supported Numpy for given Python version"
+arch=('any')
+url="https://github.com/scipy/oldest-supported-numpy"
+license=('BSD')
+depends=('python-numpy')
+makedepends=('python-setuptools')
+checkdepends=('python-nose')
+source=("https://files.pythonhosted.org/packages/source/${_pyname:0:1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
+md5sums=('122014451636fc42711301328dfdd861')
+
+get_pyver() {
+    python -c "import sys; print('$1'.join(map(str, sys.version_info[:2])))"
+}
+
+prepare() {
+    cd ${srcdir}/${_pyname}-${pkgver}
+    sed -i "/$(get_pyver .)/s/==/>=/" setup.cfg
+}
+
+build() {
+    cd ${srcdir}/${_pyname}-${pkgver}
+
+    python setup.py build
+}
+
+check() {
+    cd ${srcdir}/${_pyname}-${pkgver}
+    nosetests
+}
+
+package() {
+    cd ${srcdir}/${_pyname}-${pkgver}
+
+    install -D -m644 LICENSE -t "${pkgdir}/usr/share/licenses/${pkgname}"
+    install -D -m644 README.rst -t "${pkgdir}/usr/share/doc/${pkgname}"
+    python setup.py install --root=${pkgdir} --prefix=/usr --optimize=1
+}

--- a/BioArchLinux/python-oldest-supported-numpy/lilac.yaml
+++ b/BioArchLinux/python-oldest-supported-numpy/lilac.yaml
@@ -1,0 +1,15 @@
+maintainers:
+  - github: kbipinkumar
+    email: bipin@ccmb.res.in
+build_prefix: extra-x86_64
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+  run_cmd(['updpkgsums'])
+post_build_script: |
+  git_add_files('PKGBUILD')
+  git_commit()
+update_on:
+  - source: pypi
+    pypi: oldest-supported-numpy
+  - alias: python
+

--- a/BioArchLinux/python-pairwisedist/PKGBUILD
+++ b/BioArchLinux/python-pairwisedist/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: bipin kumar <bipin@ccmb.res.in>
+
+pkgname=python-pairwisedist
+_module=${pkgname#python-}
+pkgver=1.2.0
+pkgrel=1
+pkgdesc='Calculate the pairwise-distance matrix for an array of n samples by p features'
+arch=(any)
+url="https://github.com/GuyTeichman/pairwisedist"
+license=(Apache)
+depends=(
+         'python' 
+         'python-numpy' 
+         'python-scipy' 
+         'python-pytest'
+        )
+makedepends=(
+             'python-setuptools' 
+             'python-installer' 
+             'python-pytest-runner'
+            )
+source=("https://files.pythonhosted.org/packages/source/${_module::1}/$_module/$_module-$pkgver.tar.gz")
+md5sums=('fdd4e8e67ab8d8a6205bd1695aea75ca')
+
+build() {
+    cd "$_module-$pkgver"
+    python setup.py build
+}
+
+package() {
+    cd "$_module-$pkgver"
+    python setup.py install --root="$pkgdir/" --optimize=1 --skip-build
+    install -Dm644 "$srcdir/$_module-$pkgver/LICENSE" -t "$pkgdir/usr/share/licenses/$pkgname"
+}

--- a/BioArchLinux/python-pairwisedist/lilac.yaml
+++ b/BioArchLinux/python-pairwisedist/lilac.yaml
@@ -1,0 +1,15 @@
+maintainers:
+  - github: kbipinkumar
+    email: bipin@ccmb.res.in
+build_prefix: extra-x86_64
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+  run_cmd(['updpkgsums'])
+post_build_script: |
+  git_add_files('PKGBUILD')
+  git_commit()
+  update_aur_repo()
+update_on:
+  - source: pypi
+    pypi: pairwisedist
+  - alias: python

--- a/BioArchLinux/python-scikit-learn-extra/PKGBUILD
+++ b/BioArchLinux/python-scikit-learn-extra/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer : bipin kumar <bipin@ccmb.res.in>
+
+pkgname=python-scikit-learn-extra
+_module=${pkgname#python-}
+pkgver=0.2.0
+pkgrel=1
+pkgdesc='Python module for machine learning that extends scikit-learn'
+arch=('x86_64')
+url="https://github.com/scikit-learn-contrib/scikit-learn-extra"
+license=('MIT')
+depends=(
+        'python'
+        'python-scikit-learn'
+        'python-matplotlib'
+        'python-pytest'
+        )
+makedepends=(
+            'python-build'
+            'python-installer' 
+            'python-wheel'
+            'python-setuptools-scm'
+            'python-oldest-supported-numpy'
+            )
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_module::1}/$_module/$_module-$pkgver.tar.gz")
+sha256sums=('3b1bb5fedde47920eb4b3fa0a0c18f80cc7359d9d0496720178788c6153b8019')
+
+build() {
+    cd "$_module-$pkgver"
+    python -m build --wheel --no-isolation
+}
+
+package() {
+    cd "$_module-$pkgver"
+    python -m installer --destdir="$pkgdir" dist/*.whl
+    install -Dm644 "$srcdir/$_module-$pkgver/LICENSE" -t "$pkgdir/usr/share/licenses/$pkgname"
+}

--- a/BioArchLinux/python-scikit-learn-extra/lilac.yaml
+++ b/BioArchLinux/python-scikit-learn-extra/lilac.yaml
@@ -1,0 +1,17 @@
+maintainers:
+  - github: kbipinkumar
+    email: bipin@ccmb.res.in
+build_prefix: extra-x86_64
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+  run_cmd(['updpkgsums'])
+post_build_script: |
+  git_add_files('PKGBUILD')
+  git_commit()
+  update_aur_repo()
+repo_depends:
+  - python-oldest-supported-numpy
+update_on:
+  - source: pypi
+    pypi: scikit-learn-extra
+  - alias: python

--- a/BioArchLinux/python-upsetplot/PKGBUILD
+++ b/BioArchLinux/python-upsetplot/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Bipin Kumar <bipin@ccmb.res.in>
+
+pkgname=python-upsetplot
+_module=UpSetPlot
+pkgver=0.7.0
+pkgrel=1
+pkgdesc='Python implementation of UpSet plots by Lex et al. doi:10.1109/TVCG.2014.2346248'
+arch=(any)
+url='https://github.com/jnothman/UpSetPlot'
+license=('BSD')
+depends=(
+        'python' 
+        'python-matplotlib'
+        'python-pandas'
+        'python-seaborn')
+makedepends=(
+            'python-build'
+            'python-installer'
+            'python-wheel'
+            'python-setuptools-scm'
+            'python-pytest-runner'
+            )
+source=("https://files.pythonhosted.org/packages/source/${_module::1}/$_module/$_module-$pkgver.tar.gz")
+sha256sums=('a37e1bf19397212c2143b5004b83ecb7b0e144d1211bd2ec63654e57f87890f8')
+
+build() {
+    cd "$_module-$pkgver"
+    python -m build --wheel --no-isolation
+}
+
+package() {
+    cd "$_module-$pkgver"
+    python -m installer --destdir="$pkgdir" dist/*.whl
+    install -Dm644 "$srcdir/$_module-$pkgver/LICENSE" -t "$pkgdir/usr/share/licenses/$pkgname"
+}
+

--- a/BioArchLinux/python-upsetplot/lilac.yaml
+++ b/BioArchLinux/python-upsetplot/lilac.yaml
@@ -1,0 +1,15 @@
+maintainers:
+  - github: kbipinkumar
+    email: bipin@ccmb.res.in
+build_prefix: extra-x86_64
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+  run_cmd(['updpkgsums'])
+post_build_script: |
+  git_add_files('PKGBUILD')
+  git_commit()
+  update_aur_repo()
+update_on:
+  - source: pypi
+    pypi: UpSetPlot
+  - alias: python


### PR DESCRIPTION
## Involved packages

- python-scikit-learn-extra
- python-oldest-supported-numpy
- python-pairwisedist
- python-grid-strategy
- python-upsetplot


## Involved issue

- Close #110
- apart from aforementioned issue this pull request also adds some more dependencies mentioned in issue #107 

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [X] Provide New Package
- [X] Fix the Packages
  - [X] PKGBUILD
  - [X] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us