### PR TITLE
Adding dependencies for RNAlysis from AUR

### DIFF
--- a/BioArchLinux/bustools/PKGBUILD
+++ b/BioArchLinux/bustools/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: bipin kumar <bipin@ccmb.res.in>
+
+pkgname=bustools
+pkgver=0.42.0
+pkgrel=1
+pkgdesc='Program for manipulating BUS files for single cell RNA-Seq datasets. doi:10.1038/s41587-021-00870-2'
+url="https://github.com/BUStools/$pkgname/"
+license=(BSD)
+arch=('x86_64')
+depends=(
+		 'zlib'
+		 'gcc-libs'
+		)
+makedepends=(
+			 'cmake'
+			)
+source=($pkgname-$pkgver::"https://github.com/BUStools/bustools/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('34027724b9c57bdbf2e7c252962e30c329b3f5f9fc03d10a5feef336ce50d008')
+
+build() {
+	cd "$srcdir/$pkgname-$pkgver"
+	rm -rf build
+	mkdir -p build
+	cd build
+	cmake -DCMAKE_INSTALL_PREFIX:PATH="$pkgdir/usr" ..
+	make
+}
+
+package() {
+	cd "$srcdir/$pkgname-$pkgver/build"
+	make install
+	install -Dm644 "$srcdir/$pkgname-$pkgver/LICENSE" -t "$pkgdir/usr/share/licenses/$pkgname"
+
+}

--- a/BioArchLinux/bustools/lilac.yaml
+++ b/BioArchLinux/bustools/lilac.yaml
@@ -1,0 +1,16 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: kbipinkumar
+    email: bipin@ccmb.res.in
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+  run_cmd(['updpkgsums'])
+post_build_script: |
+  git_add_files('PKGBUILD')
+  git_commit()
+  update_aur_repo()
+update_on:
+  - source: github
+    github: BUStools/bustools
+    use_max_tag: true
+    prefix: 'v'

--- a/BioArchLinux/kallisto/PKGBUILD
+++ b/BioArchLinux/kallisto/PKGBUILD
@@ -1,0 +1,49 @@
+# import from AUR: bipin kumar <bipin@ccmb.res.in>
+# Maintainer: flying-sheep <flying-sheep@web.de>
+
+pkgname=kallisto
+pkgver=0.48.0
+pkgrel=1
+pkgdesc='Quantify abundances of transcripts from RNA-Seq data. doi:10.1038/nbt.3519'
+url="http://pachterlab.github.io/$pkgname/"
+license=(BSD)
+arch=('x86_64')
+depends=('hdf5' 'zlib')
+makedepends=('cmake')
+optdepends=('bustools')
+source=($pkgname-$pkgver::"https://github.com/pachterlab/$pkgname/archive/v$pkgver.tar.gz")
+sha256sums=('1797ac4d1f0771e3f1f25dd7972bded735fcb43f853cf52184d3d9353a6269b0')
+
+prepare() {
+	cd "$srcdir/$pkgname-$pkgver"
+
+	# https://github.com/pachterlab/kallisto/issues/303#issuecomment-884612169
+	pushd ext/htslib
+	sed -i '/AC_PROG_CC/a \
+AC_CANONICAL_HOST \
+AC_PROG_INSTALL \
+' configure.ac
+	autoreconf -i
+	autoheader
+	autoconf
+	popd
+
+	# add missing header
+	sed -i '/#include <algorithm>/a #include <limits>' src/MinCollector.cpp
+}
+
+build() {
+	cd "$srcdir/$pkgname-$pkgver"
+	rm -rf build
+	mkdir -p build
+	cd build
+	cmake -DCMAKE_INSTALL_PREFIX:PATH="$pkgdir/usr" ..
+	make
+}
+
+package() {
+	cd "$srcdir/$pkgname-$pkgver/build"
+	make install
+	install -Dm644 "$srcdir/$pkgname-$pkgver/license.txt" -t "$pkgdir/usr/share/licenses/$pkgname"
+
+}

--- a/BioArchLinux/kallisto/lilac.yaml
+++ b/BioArchLinux/kallisto/lilac.yaml
@@ -1,0 +1,15 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: kbipinkumar
+    email: bipin@ccmb.res.in
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+  run_cmd(['updpkgsums'])
+post_build_script: |
+  git_add_files('PKGBUILD')
+  git_commit()
+update_on:
+  - source: github
+    github: pachterlab/kallisto/
+    use_max_tag: true
+    prefix: 'v'

--- a/BioArchLinux/python-hdbscan/PKGBUILD
+++ b/BioArchLinux/python-hdbscan/PKGBUILD
@@ -1,0 +1,43 @@
+# import from AUR: Bipin Kumar <bipin@ccmb.res.in>
+# Maintainer: peippo <christoph+aur@christophfink.com>
+
+pkgname="python-hdbscan"
+_name=${pkgname#python-}
+pkgdesc="Hierarchical Density-Based Spatial Clustering of Applications with Noise"
+url="http://github.com/scikit-learn-contrib/hdbscan"
+
+pkgver=0.8.28
+pkgrel=1
+
+arch=("x86_64")
+license=("BSD")
+
+makedepends=(
+    "python-setuptools"
+    "cython"
+)
+depends=(
+    "python"
+    "python-numpy"
+    "python-scipy"
+    "python-scikit-learn"
+    "python-joblib"
+    "python-six"
+)
+
+source=(
+    "https://files.pythonhosted.org/packages/source/${_name::1}/$_name/$_name-$pkgver.tar.gz"
+)
+sha256sums=('eedaf71f2f3bbedfc4c38da1ad4897454ce5ebd4792e1a689c979c2853edc05a')
+
+build() {
+    cd "${srcdir}"/${_name}-${pkgver}
+    python setup.py build
+}
+
+package() {
+    cd "${srcdir}/${_name}-${pkgver}"
+    python setup.py install --root="${pkgdir}" --optimize=1
+
+    install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/BioArchLinux/python-hdbscan/lilac.yaml
+++ b/BioArchLinux/python-hdbscan/lilac.yaml
@@ -1,0 +1,14 @@
+maintainers:
+  - github: kbipinkumar
+    email: bipin@ccmb.res.in
+build_prefix: extra-x86_64
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+  run_cmd(['updpkgsums'])
+post_build_script: |
+  git_add_files('PKGBUILD')
+  git_commit()
+update_on:
+  - source: pypi
+    pypi: hdbscan
+  - alias: python

--- a/BioArchLinux/python-matplotlib-venn/PKGBUILD
+++ b/BioArchLinux/python-matplotlib-venn/PKGBUILD
@@ -1,0 +1,27 @@
+# import from AUR: bipin kumar <bipin@ccmb.res.in>
+# Maintainer: Matthew McGinn <mamcgi@gmail.com>
+# Contributor: Stunts <f.pinamartins@gmail.com>
+
+pkgname=python-matplotlib-venn
+_module=${pkgname#python-}
+pkgver=0.11.7
+pkgrel=1
+pkgdesc="Venn diagram plotting routines for python-matplotlib"
+arch=('any')
+url="https://github.com/konstantint/matplotlib-venn"
+license=('MIT')
+depends=('python-numpy' 'python-matplotlib' 'python-scipy')
+makedepends=('python-setuptools')
+source=($_module-$pkgver::"https://github.com/konstantint/matplotlib-venn/archive/refs/tags/$pkgver.tar.gz")
+b2sums=('b7290ee015aa4bd3cff73e705730e334e52dd2b94fec47c7b9d4739f2ecd382d8d666b05ff9c438439fffb2783284b31d9c513c0c0d7ca8d4650a06f797fee68')
+
+build() {
+  cd "$_module-$pkgver"
+  python setup.py build
+}
+
+package() {
+  cd "$_module-$pkgver"
+  python setup.py install --root="${pkgdir}"
+  install -Dm644 "$srcdir/$_module-$pkgver/LICENSE" -t "$pkgdir/usr/share/licenses/$pkgname"
+}

--- a/BioArchLinux/python-matplotlib-venn/lilac.yaml
+++ b/BioArchLinux/python-matplotlib-venn/lilac.yaml
@@ -1,0 +1,16 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: kbipinkumar
+    email: bipin@ccmb.res.in
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+  run_cmd(['updpkgsums'])
+post_build_script: |
+  git_add_files('PKGBUILD')
+  git_commit()
+update_on:
+  - source: github
+    github: konstantint/matplotlib-venn
+    use_max_tag: true
+    prefix: 'v'
+  - alias: python

--- a/BioArchLinux/python-numba/PKGBUILD
+++ b/BioArchLinux/python-numba/PKGBUILD
@@ -1,0 +1,43 @@
+# import from AUR: bipin kumar <bipin@ccmb.res.in>
+# Maintainer: Michael Schubert <mschu.dev at gmail> github.com/mschubert/PKGBUILDs
+pkgname=python-numba
+_module=${pkgname#python-}
+pkgver=0.56.4
+pkgrel=1
+pkgdesc="NumPy aware dynamic Python compiler using LLVM"
+url="https://numba.pydata.org/"
+arch=('i686' 'x86_64')
+license=('BSD')
+depends=('python-llvmlite>=0.39.0' 'python-llvmlite<0.40' 'python-numpy>=1.18' 'python-numpy<1.24' 'intel-tbb>=2021.1' 'python-setuptools')
+makedepends=('cython')
+optdepends=(
+            'python-scipy>=1.0.0'
+            'python-jinja' 
+            'python-cffi'
+            'ipython'
+            'python-yaml'
+            'python-colorama' 
+            'python-pygments'
+            'gdb' 
+            'graphviz'
+            'python-typeguard'
+            'python-cuda'
+            )
+source=($_module-$pkgver.tar.gz::https://github.com/numba/numba/archive/refs/tags/$pkgver.tar.gz)
+sha256sums=('ab96b731fb9dee12b404b42b7c1fb82c119352648906a80526afa73658895b73')
+
+build() {
+  cd "$srcdir/$_module-$pkgver"
+  python setup.py build
+}
+
+check_disabled() { #ERROR: TypeError None is not callable
+  cd "$srcdir/$_module-$pkgver"
+  python setup.py test
+}
+
+package() {
+  cd "$srcdir/$_module-$pkgver"
+  python setup.py install --skip-build --prefix=/usr --root="$pkgdir" --optimize=1
+  install -Dm644 "$srcdir/$_module-$pkgver/LICENSE" -t "$pkgdir/usr/share/licenses/$pkgname"
+}

--- a/BioArchLinux/python-numba/lilac.yaml
+++ b/BioArchLinux/python-numba/lilac.yaml
@@ -1,0 +1,16 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: kbipinkumar
+    email: bipin@ccmb.res.in
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+  run_cmd(['updpkgsums'])
+post_build_script: |
+  git_add_files('PKGBUILD')
+  git_commit()
+update_on:
+  - source: github
+    github: numba/numba/
+    use_max_tag: true
+    prefix: 'v'
+  - alias: python


### PR DESCRIPTION
## Involved packages

 - kallisto
 - python-numba
 - python-hdbscan
 - python-matplotlib-venn
 - bustools (optional dependency for kallisto)

## Involved issue

Additional dependencies for #107 imported from AUR

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [X] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [X] Provide New Package
- [X] Fix the Packages
  - [X] PKGBUILD
  - [X] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
All the PKGUILDS except for bustools have been imported on as is basis from AUR wherever possible with as little modification as possible. 