### PR TITLE
diamond: enable support for using BLAST databases

### DIFF
--- a/BioArchLinux/diamond/PKGBUILD
+++ b/BioArchLinux/diamond/PKGBUILD
@@ -4,35 +4,32 @@
 
 pkgname=diamond
 pkgver=2.1.0
-pkgrel=1
-pkgdesc="DIAMOND is a sequence aligner for protein and translated DNA searches, designed for high performance analysis of big sequence data https://doi.org/10.1038/s41592-021-01101-x"
+pkgrel=2
+pkgdesc="High performance sequence aligner for protein and translated DNA searches with big sequence data. https://doi.org/10.1038/s41592-021-01101-x"
 arch=('x86_64')
 url="https://github.com/bbuchfink/diamond"
 license=('GPL3')
-depends=('gcc-libs' 'zlib')
+depends=('gcc-libs' 'zlib' 'zstd' 'blast+')
 makedepends=('cmake')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/bbuchfink/diamond/archive/v$pkgver.tar.gz")
 sha256sums=('5bd04574bb454562301c10b8e2594be33a147894b173421c929939b52e251715')
 
-prepare() {
-  # shellcheck disable=2154
-  mkdir -p "$srcdir"/diamond-$pkgver/build
-}
-
 build() {
-  cd "$srcdir"/diamond-$pkgver/build
-
-  cmake \
+  cd $pkgname-$pkgver
+  cmake -B build \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCMAKE_BUILD_TYPE=Release \
-    ..
+    -DWITH_ZSTD=ON \
+    -DBLAST_INCLUDE_DIR=/usr/include/ncbi-tools++ \
+    -DBLAST_LIBRARY_DIR=/usr/lib/ \
+    -DZSTD_LIBRARY=/usr/lib/libzstd.so \
+    -DZLIB_INCLUDE_DIR=/usr/include \
+    -Wno-dev
 
-  make
+  cmake --build build
 }
 
 package() {
-  cd "$srcdir"/diamond-$pkgver/build
-
-  # shellcheck disable=2154
-  make DESTDIR="$pkgdir" install
+  cd $pkgname-$pkgver
+  DESTDIR="$pkgdir" cmake --install build
 }


### PR DESCRIPTION
## Involved packages

 - diamond

## Involved issue

Close # NA

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [x] Fix the Packages
  - [x] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
According to the [wiki ](https://github.com/bbuchfink/diamond/wiki/2.-Installation#blast-database-support)from upstream support for working with BLAST databases is not enabled by default when compiling from sources. the revised `PKGBUILD` enables the support for BLAST as per instructions from wiki.