### PR TITLE
salmon: fix cmake flags inline with Archwiki instructions

### DIFF
--- a/BioArchLinux/salmon/PKGBUILD
+++ b/BioArchLinux/salmon/PKGBUILD
@@ -1,15 +1,15 @@
-# Maintainer: bipin kumar <bipin@ccmb.res.in>
+# Maintainer: bipin kumar <kbipinkumar@pm.me>
 # Contributor: Saulius Lukauskas <luksaulius@gmail.com>
 # Contributor: Thiago L. A. Miller <thiago_leisrael@hotmail.com>
 pkgname=salmon
 pkgver=1.10.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Highly-accurate & wicked fast transcript-level quantification from RNA-seq reads using lightweight alignments"
 arch=('x86_64')
 url="https://combine-lab.github.io/$pkgname/"
-license=('GPL')
-depends=('intel-tbb'  'jemalloc' 'boost-libs' 'bzip2')
-makedepends=('boost>=1.55' 'cmake' 'unzip' 'cereal')
+license=('GPL3')
+depends=('intel-tbb'  'jemalloc' 'boost-libs')
+makedepends=('boost>=1.55' 'cmake' 'unzip' 'cereal' 'curl' 'bzip2')
 options=('!emptydirs')
 source=("$pkgname-$pkgver.tar.gz"::"https://github.com/COMBINE-lab/$pkgname/archive/v$pkgver.tar.gz")
 sha256sums=('babd9ccc189cfea07566d8a11d047f25fad5b446b4b69257bc6ad8869f8b7707')
@@ -27,22 +27,32 @@ build() {
   # FIXME: NO_IPO=TRUE is for some reason needed in 1.3.0
   #        Otherwise it is segfaulting...
 
-  cmake \
+  cmake -B build \
     -DNO_IPO:BOOL='TRUE' \
     -DCMAKE_COLOR_MAKEFILE:BOOL='ON' \
     -DCMAKE_INSTALL_PREFIX:PATH='/usr' \
+    -DCMAKE_SKIP_RPATH=YES \
     -Wno-dev \
-    -DUSE_SHARED_LIBS=ON \
-    .
+    -DBOOST_INCLUDEDIR='/usr/include' \
+    -DBOOST_LIBRARYDIR='/usr/lib' \
+    -DUSE_SHARED_LIBS=ON
 
-  make
+  cmake --build build
+}
+
+check() {
+  cd "$pkgname-$pkgver"
+
+  ctest --test-dir build --output-on-failure
+
 }
 
 package() {
   cd "$pkgname-$pkgver"
-  make DESTDIR="$pkgdir" install
+  
+  DESTDIR="$pkgdir" cmake --install build
 
-  install -Dm644 include/{*.h,*.hpp,*.tpp} -t ${pkgdir}/usr/include/${pkgname}
+  install -Dm644  include/{*.h,*.hpp,*.tpp} -t ${pkgdir}/usr/include/${pkgname}
 
   # clear cmake files
   rm -rf ${pkgdir}/usr/lib/{graphdump,ntcard,twopaco}


### PR DESCRIPTION
## Involved packages

 - salmon

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [x] Fix the Packages
  - [x] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
this pull request updates 'PKGBUILD' to be inline with arch guidelines as much as possible. 

running `namcap` on previous salmon package results in following output

```bash
salmon E: Insecure RUNPATH '$ORIGIN/../../lib' in file ('usr/bin/salmon')
salmon W: Dependency bzip2 included but already satisfied
```
package built using revised PKGBUILD produces a clean `namcap` outpu without any of aforementioned errors. 

The `PKGBUILD` has also been updated to run bundled tests provided by upstream as part of build process. 
