### PR TITLE
r-sf: rebuild with libgdal.so.33

### DIFF
--- a/BioArchLinux/r-sf/lilac.yaml
+++ b/BioArchLinux/r-sf/lilac.yaml
@@ -14,3 +14,5 @@ update_on:
   source: regex
   url: https://cran.r-project.org/package=sf
 - alias: r
+- source: manual
+  manual: 1


### PR DESCRIPTION
## Involved packages

 - r-sf

## Details

r-sf 1.0.12-2 on the bioarchlinux repo depends on `libgdal.so.32`, but the official Arch `gdal` package was updated a few days ago to provide `libgdal.so.33`.

This pr triggers a rebuild with lilac.

## Additional Note

After the Arch bug [78547](https://bugs.archlinux.org/task/78547) has been fixed, rebuilds can be automated by adding

```yaml
- source: alpm
  alpm: gdal
  repo: community
  provided: libgdal.so
```

to the `update_on` section in `lilac.yaml`.