### PR TITLE
fork fiji-bin from the AUR

### DIFF
--- a/BioArchLinux/fiji-bin/PKGBUILD
+++ b/BioArchLinux/fiji-bin/PKGBUILD
@@ -1,0 +1,40 @@
+#Maintainer: Franck Lominé <flomine@insa-rennes.fr>
+#Previous maintainer: Butui Hu <hot123tea123@gmail.com>
+#Previous maintainer: lilac <lilac@build.archlinuxcn.org>
+
+_pkgname=fiji
+pkgname=fiji-bin
+pkgver=20221201.1017
+pkgrel=1
+epoch=2
+pkgdesc="ImageJ distribution with a lot of plugins for scientific (especially biology related) image processing."
+arch=('x86_64')
+url='http://fiji.sc/'
+license=('GPL')
+depends=(
+  'freetype2'
+  'libnet'
+)
+makedepends=('gendesk')
+
+source=("${pkgname}-${pkgver}.zip::https://downloads.imagej.net/fiji/archive/${pkgver/./-}/fiji-linux64.zip")
+sha256sums=('4d78daa949cffd5300a346dadb4f64f1478d7bd582ab5cf8f51e384dfde2e9f7')
+
+
+prepare() {
+  echo "Creating desktop file"
+  gendesk -f -n --pkgname ${_pkgname} \
+    --pkgdesc "${pkgdesc}" \
+    --categories "Graphics;Science;ImageProcessing;" \
+    --icon "${_pkgname}" \
+    --exec ${_pkgname}
+}
+
+package()
+{
+  install -d "${pkgdir}/opt" "${pkgdir}/usr/bin" "${pkgdir}/usr/share/pixmaps"
+  mv "${srcdir}/Fiji.app" "${pkgdir}/opt/${_pkgname}"
+  cp "${pkgdir}/opt/${_pkgname}/images/icon.png" "${pkgdir}/usr/share/pixmaps/${_pkgname}.png"
+  ln -s "/opt/${_pkgname}/ImageJ-linux64" "${pkgdir}/usr/bin/${_pkgname}"
+  install -Dm644 "${srcdir}/fiji.desktop" "${pkgdir}/usr/share/applications/fiji.desktop"
+}

--- a/BioArchLinux/fiji-bin/lilac.yaml
+++ b/BioArchLinux/fiji-bin/lilac.yaml
@@ -1,0 +1,10 @@
+maintainers:
+- github: kiri2002
+  email: kiri@vern.cc
+build_prefix: extra-x86_64
+post_build_script: |
+  git_pkgbuild_commit()
+update_on:
+- source: regex
+  url: "https://downloads.imagej.net/fiji/archive"
+  regex: '<td><a href=\".*?/\">(.*)/</a></td>'

--- a/BioArchLinux/veusz/PKGBUILD
+++ b/BioArchLinux/veusz/PKGBUILD
@@ -1,0 +1,40 @@
+# Contributor: Andrzej Giniewicz <gginiu@gmail.com>
+# Contributor: G_Syme <demichan(at)mail(dot)upb(dot)de>
+# Contributor: Ray Kohler <ataraxia937@gmail.com>
+# Contributor: Stefan Husmann <stefan-husmann@t-online.de>
+# Contributor: moostik <mooostik_at_gmail.com>
+
+pkgname=veusz
+pkgver=3.6.2
+pkgrel=1
+pkgdesc="A 2D and 3D scientific plotting package, designed to create publication-ready PDF or SVG output"
+arch=('x86_64')
+url="https://veusz.github.io/"
+license=('GPL2')
+depends=('python-pyqt5' 'python-numpy' 'hicolor-icon-theme')
+makedepends=('sip>=6.7.5' 'python-build' 'python-installer' 'python-wheel')
+optdepends=('python-h5py:  HDF5 support'
+            'python-pyemf3: EMF export'
+            'python-dbus: dbus interface'
+            'python-iminuit: improved fitting'
+            'python-astropy: VO table import and FITS import'
+            'ghostscript: for EPS/PS output')
+source=("https://github.com/veusz/veusz/releases/download/veusz-${pkgver}/veusz-${pkgver}.tar.gz")
+sha256sums=('c2171ac45e4b30424d8fc35261e2e99dbe6e25ba1197ebc24355b106b26395d1')
+
+build() {
+  cd "${pkgname}-${pkgver}"
+  python -m build --wheel --no-isolation
+}
+
+package() {
+  cd "${pkgname}-${pkgver}"
+
+  python -m installer --destdir="$pkgdir" dist/*.whl
+  for _i in 16 32 48 64 128; do
+    install -D -m644 "icons/veusz_${_i}.png" \
+        "${pkgdir}/usr/share/icons/hicolor/${_i}x${_i}/apps/veusz.png"
+  done
+  install -D -m644 "support/veusz.desktop" \
+      "${pkgdir}/usr/share/applications/veusz.desktop"
+}

--- a/BioArchLinux/veusz/lilac.yaml
+++ b/BioArchLinux/veusz/lilac.yaml
@@ -1,0 +1,9 @@
+maintainers:
+- github: kiri2002
+  email: kiri@vern.cc
+build_prefix: extra-x86_64
+post_build_script: |
+  git_pkgbuild_commit()
+update_on:
+- source: github
+  github: veusz/veusz


### PR DESCRIPTION
fork fiji-bin from the AUR and add the lilac.yaml  While Fiji's source code is available, but various components (160+) are scattered across different repositories.(hard to collect) so just fork the bin-version, maybe figure out the de nove version in the future...

## Involved packages

 - Packages_Name

## Involved issue

Close #

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [ ] Fix the Packages
  - [ ] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
