### PR TITLE
python-pyexcel-ezodf: init

### DIFF
--- a/BioArchLinux/python-pyexcel-ezodf/PKGBUILD
+++ b/BioArchLinux/python-pyexcel-ezodf/PKGBUILD
@@ -11,15 +11,12 @@ license=('MIT')
 depends=(
          'python'
          'python-lxml'
-         'python-weakrefset'
         )
 makedepends=(
              'python-setuptools'
-             'python-installer'
-             'python-pytest-runner'
             )
 source=("https://github.com/pyexcel/${_module}/archive/refs/tags/v${pkgver}.tar.gz")
-md5sums=('792949bc5b8abba9209f22ec9af15a41')
+sha256sums=('0419c5b94a5d02d7fcefe5af4b4f91b3b07da157e62053aea48da2fe0364178e')
 
 build() {
     cd "$_module-$pkgver"
@@ -29,4 +26,5 @@ build() {
 package() {
     cd "$_module-$pkgver"
     python setup.py install --root="$pkgdir/" --optimize=1 --skip-build
+    install -Dm644 "$srcdir/${_module}-${pkgver}/LICENSE.txt"  "${pkgdir}/usr/share/licenses/${pkgname}"/LICENSE
 }

--- a/BioArchLinux/python-pyexcel-ezodf/PKGBUILD
+++ b/BioArchLinux/python-pyexcel-ezodf/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer: Kiri <kiri@vern.cc>
+
+pkgname=python-pyexcel-ezodf
+_module=${pkgname#python-}
+pkgver=0.3.4
+pkgrel=1
+pkgdesc='A Python package to create/manipulate OpenDocumentFormat files'
+arch=(any)
+url="https://github.com/pyexcel/pyexcel-ezodf"
+license=('MIT')
+depends=(
+         'python'
+         'python-lxml'
+         'python-weakrefset'
+        )
+makedepends=(
+             'python-setuptools'
+             'python-installer'
+             'python-pytest-runner'
+            )
+source=("https://github.com/pyexcel/${_module}/archive/refs/tags/v${pkgver}.tar.gz")
+md5sums=('792949bc5b8abba9209f22ec9af15a41')
+
+build() {
+    cd "$_module-$pkgver"
+    python setup.py build
+}
+
+package() {
+    cd "$_module-$pkgver"
+    python setup.py install --root="$pkgdir/" --optimize=1 --skip-build
+}

--- a/BioArchLinux/python-pyexcel-ezodf/PKGBUILD
+++ b/BioArchLinux/python-pyexcel-ezodf/PKGBUILD
@@ -26,5 +26,5 @@ build() {
 package() {
     cd "$_module-$pkgver"
     python setup.py install --root="$pkgdir/" --optimize=1 --skip-build
-    install -Dm644 "$srcdir/${_module}-${pkgver}/LICENSE.txt"  "${pkgdir}/usr/share/licenses/${pkgname}"/LICENSE
+    install -Dm644 "$srcdir/${_module}-${pkgver}/LICENSE.txt"  "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/BioArchLinux/python-pyexcel-ezodf/lilac.yaml
+++ b/BioArchLinux/python-pyexcel-ezodf/lilac.yaml
@@ -8,6 +8,8 @@ pre_build_script: |
 post_build_script: |
   git_pkgbuild_commit()
   update_aur_repo()
+repo_depends:
+  - python-weakrefset
 update_on:
   - source: github
     github: pyexcel/pyexcel-ezodf

--- a/BioArchLinux/python-pyexcel-ezodf/lilac.yaml
+++ b/BioArchLinux/python-pyexcel-ezodf/lilac.yaml
@@ -7,7 +7,6 @@ pre_build_script: |
   run_cmd(['updpkgsums'])
 post_build_script: |
   git_pkgbuild_commit()
-  update_aur_repo()
 repo_depends:
   - python-weakrefset
 update_on:

--- a/BioArchLinux/python-pyexcel-ezodf/lilac.yaml
+++ b/BioArchLinux/python-pyexcel-ezodf/lilac.yaml
@@ -7,8 +7,6 @@ pre_build_script: |
   run_cmd(['updpkgsums'])
 post_build_script: |
   git_pkgbuild_commit()
-repo_depends:
-  - python-weakrefset
 update_on:
   - source: github
     github: pyexcel/pyexcel-ezodf

--- a/BioArchLinux/python-pyexcel-ezodf/lilac.yaml
+++ b/BioArchLinux/python-pyexcel-ezodf/lilac.yaml
@@ -1,0 +1,16 @@
+maintainers:
+  - github: kiri2002
+    email: kiri@vern.cc
+build_prefix: extra-x86_64
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+  run_cmd(['updpkgsums'])
+post_build_script: |
+  git_pkgbuild_commit()
+  update_aur_repo()
+update_on:
+  - source: github
+    github: pyexcel/pyexcel-ezodf
+    use_latest_release: true
+    prefix: 'v'
+  - alias: python


### PR DESCRIPTION
add python-pyexcel-ezodf as dependence for jamovi

## Involved packages

 - python-pyexcel-ezodf

## Involved issue

Close #

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [x] Provide New Package
- [ ] Fix the Packages
  - [x] PKGBUILD
  - [x] lilac.yaml
  - [ ] lilac.py
- [x] Would like to continue to work with us

## Additional Note
