### PR TITLE
jamovi*: add r-pkgs depends

### DIFF
--- a/BioArchLinux/r-exact2x2/PKGBUILD
+++ b/BioArchLinux/r-exact2x2/PKGBUILD
@@ -1,0 +1,35 @@
+# Maintainer: Kiri <kiri@vern.cc>
+
+_pkgname=exact2x2
+_pkgver=1.6.8
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//[:-]/.}
+pkgrel=1
+pkgdesc='Exact Tests and Confidence Intervals for 2x2 Tables'
+arch=('any')
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('GPL')
+depends=(
+  r
+  r-exactci
+  r-ssanv
+)
+optdepends=(
+  r-exact
+  r-ggplot2
+  r-grid
+  r-gridextra
+  r-testthat
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+sha256sums=('9717933a5baa86b242e1a611860f984f660c089c7b3f765fe14ca582a07b98f1')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}
+# vim:set ts=2 sw=2 et:

--- a/BioArchLinux/r-exact2x2/lilac.yaml
+++ b/BioArchLinux/r-exact2x2/lilac.yaml
@@ -4,6 +4,8 @@ maintainers:
 repo_depends:
 - r-exactci
 - r-ssanv
+post_build_script: |
+  git_pkgbuild_commit()
 update_on:
 - source: rpkgs
   pkgname: exact2x2

--- a/BioArchLinux/r-exact2x2/lilac.yaml
+++ b/BioArchLinux/r-exact2x2/lilac.yaml
@@ -4,6 +4,12 @@ maintainers:
 repo_depends:
 - r-exactci
 - r-ssanv
+pre_build_script: |
+  for line in edit_file('PKGBUILD'):
+    if line.startswith('_pkgver='):
+      line = f'_pkgver={_G.newver}'
+    print(line)
+  update_pkgver_and_pkgrel(_G.newver.replace(':', '.').replace('-', '.'))
 post_build_script: |
   git_pkgbuild_commit()
 update_on:

--- a/BioArchLinux/r-exact2x2/lilac.yaml
+++ b/BioArchLinux/r-exact2x2/lilac.yaml
@@ -5,6 +5,7 @@ repo_depends:
 - r-exactci
 - r-ssanv
 update_on:
-- regex: exact2x2_([\d._-]+).tar.gz
-  source: regex
-  url: https://cran.r-project.org/package=exact2x2
+- source: rpkgs
+  pkgname: exact2x2
+  repo: cran
+- alias: r

--- a/BioArchLinux/r-exact2x2/lilac.yaml
+++ b/BioArchLinux/r-exact2x2/lilac.yaml
@@ -1,0 +1,10 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: kiri2002
+repo_depends:
+- r-exactci
+- r-ssanv
+update_on:
+- regex: exact2x2_([\d._-]+).tar.gz
+  source: regex
+  url: https://cran.r-project.org/package=exact2x2

--- a/BioArchLinux/r-exactci/PKGBUILD
+++ b/BioArchLinux/r-exactci/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Kiri <kiri@vern.cc>
+
+_pkgname=exactci
+_pkgver=1.4-2
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//[:-]/.}
+pkgrel=1
+pkgdesc='Exact P-Values and Matching Confidence Intervals for Simple Discrete Parametric Cases'
+arch=('any')
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('GPL')
+depends=(
+  r
+  r-ssanv
+  r-testthat
+)
+optdepends=(
+  r-blakerci
+  r-knitr
+  r-rmarkdown
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+sha256sums=('279294a0ef7c9e968ef5d9c321f53430bdf3aaab787aebf892d5b8236fc5f022')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}
+# vim:set ts=2 sw=2 et:

--- a/BioArchLinux/r-exactci/lilac.yaml
+++ b/BioArchLinux/r-exactci/lilac.yaml
@@ -4,7 +4,10 @@ maintainers:
 repo_depends:
 - r-ssanv
 - r-testthat
+post_build_script: |
+  git_pkgbuild_commit()
 update_on:
-- regex: exactci_([\d._-]+).tar.gz
-  source: regex
-  url: https://cran.r-project.org/package=exactci
+- source: rpkgs
+  pkgname: exactci
+  repo: cran
+- alias: r

--- a/BioArchLinux/r-exactci/lilac.yaml
+++ b/BioArchLinux/r-exactci/lilac.yaml
@@ -1,0 +1,10 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: kiri2002
+repo_depends:
+- r-ssanv
+- r-testthat
+update_on:
+- regex: exactci_([\d._-]+).tar.gz
+  source: regex
+  url: https://cran.r-project.org/package=exactci

--- a/BioArchLinux/r-exactci/lilac.yaml
+++ b/BioArchLinux/r-exactci/lilac.yaml
@@ -4,6 +4,12 @@ maintainers:
 repo_depends:
 - r-ssanv
 - r-testthat
+pre_build_script: |
+  for line in edit_file('PKGBUILD'):
+    if line.startswith('_pkgver='):
+      line = f'_pkgver={_G.newver}'
+    print(line)
+  update_pkgver_and_pkgrel(_G.newver.replace(':', '.').replace('-', '.'))
 post_build_script: |
   git_pkgbuild_commit()
 update_on:

--- a/BioArchLinux/r-mvnormtest/PKGBUILD
+++ b/BioArchLinux/r-mvnormtest/PKGBUILD
@@ -1,0 +1,26 @@
+# Maintainer: Kiri <kiri@vern.cc>
+
+_pkgname=mvnormtest
+_pkgver=0.1-9
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//[:-]/.}
+pkgrel=1
+pkgdesc='Normality test for multivariate variables'
+arch=('any')
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('GPL')
+depends=(
+  r
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+sha256sums=('46dab6eb9e7d55b8d4054d14029613b89a308259f86ddc8952b0bf752e975dc5')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}
+# vim:set ts=2 sw=2 et:

--- a/BioArchLinux/r-mvnormtest/lilac.yaml
+++ b/BioArchLinux/r-mvnormtest/lilac.yaml
@@ -1,7 +1,16 @@
 build_prefix: extra-x86_64
 maintainers:
 - github: kiri2002
+pre_build_script: |
+  for line in edit_file('PKGBUILD'):
+    if line.startswith('_pkgver='):
+      line = f'_pkgver={_G.newver}'
+    print(line)
+  update_pkgver_and_pkgrel(_G.newver.replace(':', '.').replace('-', '.'))
+post_build_script: |
+  git_pkgbuild_commit()
 update_on:
-- regex: mvnormtest_([\d._-]+).tar.gz
-  source: regex
-  url: https://cran.r-project.org/package=mvnormtest
+- source: rpkgs
+  pkgname: mvnormtest
+  repo: cran
+- alias: r

--- a/BioArchLinux/r-mvnormtest/lilac.yaml
+++ b/BioArchLinux/r-mvnormtest/lilac.yaml
@@ -1,0 +1,7 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: kiri2002
+update_on:
+- regex: mvnormtest_([\d._-]+).tar.gz
+  source: regex
+  url: https://cran.r-project.org/package=mvnormtest

--- a/BioArchLinux/r-pmcmr/PKGBUILD
+++ b/BioArchLinux/r-pmcmr/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: Kiri <kiri@vern.cc>
+
+_pkgname=PMCMR
+_pkgver=4.4
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//[:-]/.}
+pkgrel=1
+pkgdesc='Calculate Pairwise Multiple Comparisons of Mean Rank Sums'
+arch=('any')
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('GPL')
+depends=(
+  r
+)
+optdepends=(
+  r-multcompview
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+sha256sums=('e7b4d9d595a879a62c9b3bb44c1f95432ad75a6607f84ce6bfc6395fee1dc116')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}
+# vim:set ts=2 sw=2 et:

--- a/BioArchLinux/r-pmcmr/lilac.yaml
+++ b/BioArchLinux/r-pmcmr/lilac.yaml
@@ -1,7 +1,16 @@
 build_prefix: extra-x86_64
 maintainers:
 - github: kiri2002
+pre_build_script: |
+  for line in edit_file('PKGBUILD'):
+    if line.startswith('_pkgver='):
+      line = f'_pkgver={_G.newver}'
+    print(line)
+  update_pkgver_and_pkgrel(_G.newver.replace(':', '.').replace('-', '.'))
+post_build_script: |
+  git_pkgbuild_commit()
 update_on:
-- regex: PMCMR_([\d._-]+).tar.gz
-  source: regex
-  url: https://cran.r-project.org/package=PMCMR
+- source: rpkgs
+  pkgname: pmcmr
+  repo: cran
+- alias: r

--- a/BioArchLinux/r-pmcmr/lilac.yaml
+++ b/BioArchLinux/r-pmcmr/lilac.yaml
@@ -11,6 +11,6 @@ post_build_script: |
   git_pkgbuild_commit()
 update_on:
 - source: rpkgs
-  pkgname: pmcmr
+  pkgname: PMCMR
   repo: cran
 - alias: r

--- a/BioArchLinux/r-pmcmr/lilac.yaml
+++ b/BioArchLinux/r-pmcmr/lilac.yaml
@@ -1,0 +1,7 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: kiri2002
+update_on:
+- regex: PMCMR_([\d._-]+).tar.gz
+  source: regex
+  url: https://cran.r-project.org/package=PMCMR

--- a/BioArchLinux/r-regsem/PKGBUILD
+++ b/BioArchLinux/r-regsem/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Kiri <kiri@vern.cc>
+
+_pkgname=regsem
+_pkgver=1.9.5
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//[:-]/.}
+pkgrel=1
+pkgdesc='Regularized Structural Equation Modeling'
+arch=('x86_64')
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('GPL')
+depends=(
+  r
+  r-lavaan
+  r-rcpp
+  r-rcpparmadillo
+  r-rsolnp
+)
+optdepends=(
+  r-caret
+  r-colorspace
+  r-ga
+  r-glmnet
+  r-islr
+  r-knitr
+  r-lbfgs
+  r-markdown
+  r-mass
+  r-matrixstats
+  r-nlcoptim
+  r-nloptr
+  r-numderiv
+  r-optimx
+  r-plyr
+  r-psych
+  r-semplot
+  r-snowfall
+  r-stringr
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+sha256sums=('7392bd644efe82f96da0df470a962de398f1d0162273cba1ff31c2ecd7f17a53')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}
+# vim:set ts=2 sw=2 et:

--- a/BioArchLinux/r-regsem/lilac.yaml
+++ b/BioArchLinux/r-regsem/lilac.yaml
@@ -6,7 +6,16 @@ repo_depends:
 - r-rcpp
 - r-rcpparmadillo
 - r-rsolnp
+pre_build_script: |
+  for line in edit_file('PKGBUILD'):
+    if line.startswith('_pkgver='):
+      line = f'_pkgver={_G.newver}'
+    print(line)
+  update_pkgver_and_pkgrel(_G.newver.replace(':', '.').replace('-', '.'))
+post_build_script: |
+  git_pkgbuild_commit()
 update_on:
-- regex: regsem_([\d._-]+).tar.gz
-  source: regex
-  url: https://cran.r-project.org/package=regsem
+- source: rpkgs
+  pkgname: regsem
+  repo: cran
+- alias: r

--- a/BioArchLinux/r-regsem/lilac.yaml
+++ b/BioArchLinux/r-regsem/lilac.yaml
@@ -1,0 +1,12 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: kiri2002
+repo_depends:
+- r-lavaan
+- r-rcpp
+- r-rcpparmadillo
+- r-rsolnp
+update_on:
+- regex: regsem_([\d._-]+).tar.gz
+  source: regex
+  url: https://cran.r-project.org/package=regsem

--- a/BioArchLinux/r-rprotobuf/PKGBUILD
+++ b/BioArchLinux/r-rprotobuf/PKGBUILD
@@ -11,6 +11,7 @@ arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"
 license=('GPL')
 depends=(
+  protobuf
   r
   r-rcpp
 )

--- a/BioArchLinux/r-rprotobuf/PKGBUILD
+++ b/BioArchLinux/r-rprotobuf/PKGBUILD
@@ -1,0 +1,31 @@
+# system requirements: ProtoBuf libraries and compiler version 3.3.0 orlater; On Debian/Ubuntu these can be installed aslibprotoc-dev, libprotobuf-dev and protobuf-compiler, while onFedora/CentOS protobuf-devel and protobuf-compiler are needed.A C++17 compiler is required as well.
+# Maintainer: Kiri <kiri@vern.cc>
+
+_pkgname=RProtoBuf
+_pkgver=0.4.20
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//[:-]/.}
+pkgrel=1
+pkgdesc="R Interface to the 'Protocol Buffers' 'API' (Version 2 or 3)"
+arch=('x86_64')
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('GPL')
+depends=(
+  r
+  r-rcpp
+)
+optdepends=(
+  r-tinytest
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+sha256sums=('e6608210d8077253cd0b09d16499f79ef8ce2de42365828a38848c615069bce0')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}
+# vim:set ts=2 sw=2 et:

--- a/BioArchLinux/r-rprotobuf/lilac.yaml
+++ b/BioArchLinux/r-rprotobuf/lilac.yaml
@@ -3,7 +3,21 @@ maintainers:
 - github: kiri2002
 repo_depends:
 - r-rcpp
+pre_build_script: |
+  for line in edit_file('PKGBUILD'):
+    if line.startswith('_pkgver='):
+      line = f'_pkgver={_G.newver}'
+    print(line)
+  update_pkgver_and_pkgrel(_G.newver.replace(':', '.').replace('-', '.'))
+post_build_script: |
+  git_pkgbuild_commit()
 update_on:
-- regex: RProtoBuf_([\d._-]+).tar.gz
-  source: regex
-  url: https://cran.r-project.org/package=RProtoBuf
+- source: rpkgs
+  pkgname: rprotobuf
+  repo: cran
+- alias: r
+- source: alpm
+  alpm: protobuf
+  repo: extra
+  provided: libprotobuf.so
+  strip_release: true

--- a/BioArchLinux/r-rprotobuf/lilac.yaml
+++ b/BioArchLinux/r-rprotobuf/lilac.yaml
@@ -13,7 +13,7 @@ post_build_script: |
   git_pkgbuild_commit()
 update_on:
 - source: rpkgs
-  pkgname: rprotobuf
+  pkgname: RProtoBuf
   repo: cran
 - alias: r
 - source: alpm

--- a/BioArchLinux/r-rprotobuf/lilac.yaml
+++ b/BioArchLinux/r-rprotobuf/lilac.yaml
@@ -1,0 +1,9 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: kiri2002
+repo_depends:
+- r-rcpp
+update_on:
+- regex: RProtoBuf_([\d._-]+).tar.gz
+  source: regex
+  url: https://cran.r-project.org/package=RProtoBuf

--- a/BioArchLinux/r-ssanv/PKGBUILD
+++ b/BioArchLinux/r-ssanv/PKGBUILD
@@ -1,0 +1,26 @@
+# Maintainer: Kiri <kiri@vern.cc>
+
+_pkgname=ssanv
+_pkgver=1.1
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//[:-]/.}
+pkgrel=1
+pkgdesc='Sample Size Adjusted for Nonadherence or Variability of Input Parameters'
+arch=('any')
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('GPL')
+depends=(
+  r
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+sha256sums=('4dea3fefe2d9da6a3020d19dea2ebc6634df38cbce0415fb16b0d4fe5551449d')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}
+# vim:set ts=2 sw=2 et:

--- a/BioArchLinux/r-ssanv/lilac.yaml
+++ b/BioArchLinux/r-ssanv/lilac.yaml
@@ -1,0 +1,7 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: kiri2002
+update_on:
+- regex: ssanv_([\d._-]+).tar.gz
+  source: regex
+  url: https://cran.r-project.org/package=ssanv

--- a/BioArchLinux/r-ssanv/lilac.yaml
+++ b/BioArchLinux/r-ssanv/lilac.yaml
@@ -14,8 +14,3 @@ update_on:
   pkgname: ssanv
   repo: cran
 - alias: r
-- source: alpm
-  alpm: protobuf
-  repo: extra
-  provided: libprotobuf.so
-  strip_release: true

--- a/BioArchLinux/r-ssanv/lilac.yaml
+++ b/BioArchLinux/r-ssanv/lilac.yaml
@@ -1,10 +1,21 @@
 build_prefix: extra-x86_64
 maintainers:
 - github: kiri2002
+pre_build_script: |
+  for line in edit_file('PKGBUILD'):
+    if line.startswith('_pkgver='):
+      line = f'_pkgver={_G.newver}'
+    print(line)
+  update_pkgver_and_pkgrel(_G.newver.replace(':', '.').replace('-', '.'))
 post_build_script: |
   git_pkgbuild_commit()
 update_on:
 - source: rpkgs
-  pkgname: ssanv
+  pkgname: 
   repo: cran
 - alias: r
+- source: alpm
+  alpm: protobuf
+  repo: extra
+  provided: libprotobuf.so
+  strip_release: true

--- a/BioArchLinux/r-ssanv/lilac.yaml
+++ b/BioArchLinux/r-ssanv/lilac.yaml
@@ -1,7 +1,10 @@
 build_prefix: extra-x86_64
 maintainers:
 - github: kiri2002
+post_build_script: |
+  git_pkgbuild_commit()
 update_on:
-- regex: ssanv_([\d._-]+).tar.gz
-  source: regex
-  url: https://cran.r-project.org/package=ssanv
+- source: rpkgs
+  pkgname: ssanv
+  repo: cran
+- alias: r

--- a/BioArchLinux/r-ssanv/lilac.yaml
+++ b/BioArchLinux/r-ssanv/lilac.yaml
@@ -11,7 +11,7 @@ post_build_script: |
   git_pkgbuild_commit()
 update_on:
 - source: rpkgs
-  pkgname: 
+  pkgname: ssanv
   repo: cran
 - alias: r
 - source: alpm


### PR DESCRIPTION
add r-pkgs depended by jamovi
using cran2pkgbuild.py

## Involved packages

 - Packages_Name

## Involved issue

Close #

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [ ] Fix the Packages
  - [ ] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
