### PR TITLE
python-orange3: Fix dependence

### DIFF
--- a/BioArchLinux/python-orange3/PKGBUILD
+++ b/BioArchLinux/python-orange3/PKGBUILD
@@ -30,7 +30,7 @@ depends=(python
          python-pygments
          python-pyqtgraph
          python-python-louvain
-         python-pyyaml
+         python-yaml
          python-qtconsole
          python-requests
          python-scikit-learn

--- a/BioArchLinux/python-orange3/lilac.yaml
+++ b/BioArchLinux/python-orange3/lilac.yaml
@@ -13,7 +13,6 @@ update_on:
   - alias: python
 repo_depends:
   - python-orange-canvas-core
-  - python-pyyaml
   - python-baycomp
   - python-python-louvain
   - python-serverfiles


### PR DESCRIPTION
## Involved packages

 - python-orange3

## Involved issue

fix the denpendence from python-pyyaml to python-yaml
the pypi pkg named pyyaml so the script auto write 'python-pyyaml'  but in extra it's 'python-yaml'

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [x] Fix the Packages
  - [x] PKGBUILD
  - [x] lilac.yaml
  - [ ] lilac.py
- [x] Would like to continue to work with us

## Additional Note
