### PR TITLE
fastqc: fix build and startup when default java is too old

### DIFF
--- a/BioArchLinux/fastqc/PKGBUILD
+++ b/BioArchLinux/fastqc/PKGBUILD
@@ -7,27 +7,30 @@ pkgver=0.12.1
 pkgrel=3
 pkgdesc='A quality control tool for high throughput sequence data.'
 arch=('any')
-url="http://www.bioinformatics.babraham.ac.uk/projects/fastqc"
+url="https://www.bioinformatics.babraham.ac.uk/projects/fastqc"
 license=('GPL3')
 depends=('perl' 'java-runtime>=11' 'ttf-dejavu')
 makedepends=('ant' 'java-environment>=11')
-source=("$pkgname-$pkgver::https://github.com/s-andrews/FastQC/archive/refs/tags/v${pkgver}.tar.gz"
-	"$pkgname.patch::https://github.com/s-andrews/FastQC/commit/e73f094ec165882cc71707a5dd5d3dd263a51b83.patch")
-md5sums=('2d22a29649394f589e6f03d8d8c3eec9'
-         '37a54b16eeb73d39a88893e326192e29')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/s-andrews/FastQC/archive/refs/tags/v${pkgver}.tar.gz"
+        "fastqc.sh"
+        "$pkgname.patch::https://github.com/s-andrews/FastQC/commit/e73f094ec165882cc71707a5dd5d3dd263a51b83.patch")
+sha256sums=('cad8bfd11ecf388204c28a62b162dda032aac8ecd08819c49b053aa66613e92b'
+            'e1b8e3d5ef1b5804af65f888edbd89c98018b8b43fc114e7cc6bada741c9a352'
+            '61cdeadcc3f2885a4aa5412ea2b215364f279ffc5aecec513afa2bc00c182c15')
 prepare() {
   cd $_pkgname-$pkgver
-  patch -p1 < $srcdir/$pkgname.patch
+  patch -p1 -i "../$pkgname.patch"
 }
 build() {
   cd $_pkgname-$pkgver
-  ant
+  # use latest available java
+  local _javaenv="$(archlinux-java status | tail -n +2 | cut -d ' ' -f 3 | sort -nk 2 -t - | tail -n 1)"
+  JAVA_HOME="/usr/lib/jvm/$_javaenv" ant
 }
 package() {
-  mkdir -p $pkgdir/usr/share/$pkgname/
-  cp -r $srcdir/$_pkgname-$pkgver/bin/* $pkgdir/usr/share/$pkgname/
+  install -d "$pkgdir/usr/share/$pkgname"
+  cp -r "$_pkgname-$pkgver/bin"/* "$pkgdir/usr/share/$pkgname/"
+  chmod 755 "$pkgdir/usr/share/$pkgname/fastqc"
 
-  mkdir -p "${pkgdir}/usr/bin/"
-  chmod 755 $pkgdir/usr/share/$pkgname/fastqc
-  ln -s "/usr/share/$pkgname/fastqc" "${pkgdir}/usr/bin/"
+  install -Dm755 fastqc.sh "$pkgdir/usr/bin/fastqc"
 }

--- a/BioArchLinux/fastqc/fastqc.sh
+++ b/BioArchLinux/fastqc/fastqc.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if [ -n "$FASTQC_JAVA" ]; then
+  javaenv="$FASTQC_JAVA"
+else
+  default_java="$(archlinux-java get)"
+  if [ "$(echo "$default_java" | cut -d - -f 2)" -ge 11 ]; then
+    javaenv="$default_java"
+  else
+    # use latest available java
+    javaenv="$(archlinux-java status | tail -n +2 | cut -d ' ' -f 3 | sort -nk 2 -t - | tail -n 1)"
+  fi
+fi
+
+PATH="/usr/lib/jvm/$javaenv/bin:$PATH" exec /usr/share/fastqc/fastqc "$@"


### PR DESCRIPTION
## Involved packages

 - fastqc

## Involved issue

Close #130

## Details
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [x] Fix the Packages
  - [x] PKGBUILD

## Additional Note

@mmahmoudian

As said in the bug report, `fastqc` fails to build in a non-chroot environment, if the default java version (as set by `archlinux-java`) is older than 11. In addition to that, the application fails to launch if the default java is older than 11. This bug is not Manjaro specific, as it has been tested on Arch.

This patch makes the package use the latest available java version during build. The make dependency `java-environment>=11` guarantees that a recent one is available. During application startup the latest available java is chosen as well, if the default java is too old.