### PR TITLE
canu: use external mhap packaged in repo

### DIFF
--- a/BioArchLinux/canu/PKGBUILD
+++ b/BioArchLinux/canu/PKGBUILD
@@ -1,33 +1,56 @@
 # Maintainer: Chocobo1 <chocobo1 AT archlinux DOT net>
 # Previous maintainer: Roberto Rossini ("robymetallo") <roberto.rossini.9533@student.uu.se>
-
-pkgname=canu
+# Contributor: Bipin Kumar <kbipinkumar@pm.me>
+pkgname=canu 
 pkgver=2.2
 pkgrel=4
-pkgdesc="A fork of the Celera Assembler designed for high-noise single-molecule sequencing"
+pkgdesc="A single molecule sequence assembler for large and small genomes. https://doi.org/10.1101/gr.215087.116"
 arch=('i686' 'x86_64')
-url="https://canu.readthedocs.io/"
+url="https://canu.readthedocs.io/en/latest/"
 license=('custom')
-depends=('glibc' 'java-runtime' 'perl')
+makedepends=('git')
+depends=('gcc-libs' 'glibc' 'perl' 'mhap')
 optdepends=('gnuplot')
 options=('staticlibs')
-source=("$pkgname-$pkgver-src.tar.xz::https://github.com/marbl/canu/releases/download/v$pkgver/canu-$pkgver.tar.xz")
-sha256sums=('e4d0c7b82149114f442ccd39e18f7fe2061c63b28d53700ad896e022b73b7404')
+source=("${pkgname}.${pkgver}.tar.xz::https://github.com/marbl/canu/releases/download/v${pkgver}/canu-${pkgver}.tar.xz"
+        'use-arch-mhap-at-runtime.patch'
+'external-mhap.patch'
+'canu_version.patch'
+)
+provides=('meryl')
+sha256sums=('e4d0c7b82149114f442ccd39e18f7fe2061c63b28d53700ad896e022b73b7404'
+            'd94a1f933d34448a94d43b300bf7ac9294898a6a7dac4b47fb4f6c6e76762e4d'
+            'efcfa7aab0752eba85c7c9a56048b838e44076221bc6f4b37377ca16f347788f'
+            '04f84c399232d5433fcec2e62294f0d767608ae39a0bff937a50356bd44b2660')
 
+prepare() {
+  cp *.patch ${pkgname}-${pkgver}/
+  cd ${pkgname}-${pkgver}
+  patch -p1 < use-arch-mhap-at-runtime.patch
+  patch -p1 < external-mhap.patch
+  patch -p1 < canu_version.patch
+}
 
 build() {
-  cd "$pkgname-$pkgver"
-
-  make -C "src"
+  cd ${pkgname}-${pkgver}/src
+  make
 }
 
 package() {
-  cd "$pkgname-$pkgver"
-
-  install -Dm755 "build/bin"/* -t "$pkgdir/usr/bin"
-  install -Dm644 "build/lib/site_perl/canu"/*.pm -t "$pkgdir/usr/lib/site_perl/canu"
-  install -Dm644 "build/share/java/classes"/*.jar -t "$pkgdir/usr/share/java/classes"
-  install -Dm644 "build/lib"/*.a -t "$pkgdir/usr/lib"
-
-  install -Dm644 "README.licenses" -t "$pkgdir/usr/share/licenses/canu"
+  cd ${pkgname}-${pkgver}/build  
+  install -d $pkgdir/usr/bin
+  for bin in bin/*
+  do [ -f "$bin" ] || continue
+  install -Dm755 ${bin} $pkgdir/usr/${bin}
+  done
+  install -d $pkgdir/usr/lib
+  for file in lib/*
+  do [ -f "$file" ] || continue
+  install -Dm644 ${file} $pkgdir/usr/${file}
+  done
+  for file in lib/site_perl/canu/*
+  do [ -f "$file" ] || continue
+  install -Dm644 ${file} $pkgdir/usr/${file}
+  done
+  install -Dm644 ../README.licenses -t "$pkgdir/usr/share/licenses/canu"
 }

--- a/BioArchLinux/canu/canu_version.patch
+++ b/BioArchLinux/canu/canu_version.patch
@@ -1,0 +1,12 @@
+--- canu-2.2.orig/scripts/version_update.pl	2021-08-27 01:27:04.000000000 +0530
++++ canu-2.2.new/scripts/version_update.pl	2023-06-24 11:43:58.925026735 +0530
+@@ -61,7 +61,8 @@
+ 
+ #  If in a git repo, we can get the actual values.
+ 
+-if (-d "../.git") {
++#if (-d "../.git") {
++if (0) {
+     $label = "snapshot";
+ 
+     #  Count the number of changes since the last release.

--- a/BioArchLinux/canu/external-mhap.patch
+++ b/BioArchLinux/canu/external-mhap.patch
@@ -1,0 +1,12 @@
+Description: remove bundled mhap from being installed.
+===================================================================
+--- canu-2.2.orig/src/Makefile	2021-08-27 01:27:04.000000000 +0530
++++ canu-2.2.new/src/Makefile	2023-06-24 11:49:01.274587478 +0530
+@@ -679,7 +679,6 @@
+      ${TARGET_DIR}/bin/canu-time \
+      ${TARGET_DIR}/bin/draw-tig \
+      ${TARGET_DIR}/bin/canu.defaults \
+-     ${TARGET_DIR}/share/java/classes/mhap-2.1.3.jar \
+      ${TARGET_DIR}/lib/site_perl/canu/Consensus.pm \
+      ${TARGET_DIR}/lib/site_perl/canu/CorrectReads.pm \
+      ${TARGET_DIR}/lib/site_perl/canu/HaplotypeReads.pm \

--- a/BioArchLinux/canu/lilac.yaml
+++ b/BioArchLinux/canu/lilac.yaml
@@ -2,8 +2,10 @@ build_prefix: extra-x86_64
 maintainers:
   - github: starsareintherose
     email: kuoi@bioarchlinux.org
+repo_depends:
+  - mhap
 update_on:
   - source: github
     github: marbl/canu
     use_latest_release: true
-    prefix: 'v'
+    prefix: 'v' 

--- a/BioArchLinux/canu/use-arch-mhap-at-runtime.patch
+++ b/BioArchLinux/canu/use-arch-mhap-at-runtime.patch
@@ -1,0 +1,22 @@
+Description: Use mhap jar from mhap package provided by Bioarchlinux repo
+===================================================================
+--- canu-2.2.orig/src/pipelines/canu/OverlapMhap.pm	2021-08-27 01:27:04.000000000 +0530
++++ canu-2.2.new/src/pipelines/canu/OverlapMhap.pm	2023-06-24 11:58:23.382864802 +0530
+@@ -345,7 +345,7 @@
+     print F "cd ./blocks\n";
+     print F "\n";
+     print F "$javaPath $javaOpt -XX:ParallelGCThreads=",  getGlobal("${tag}mhapThreads"), " -server -Xms", $javaMemory, "m -Xmx", $javaMemory, "m \\\n";
+-    print F "  -jar $cygA \$bin/../share/java/classes/mhap-" . getGlobal("${tag}MhapVersion") . ".jar $cygB \\\n";
++    print F "  -jar $cygA /usr/share/mhap/mhap.jar $cygB \\\n";
+     print F "  --repeat-weight 0.9 --repeat-idf-scale 10 -k $merSize \\\n";
+     print F "  --supress-noise 2 \\\n"  if (defined(getGlobal("${tag}MhapFilterUnique")) && getGlobal("${tag}MhapFilterUnique") == 1);
+     print F "  --no-tf \\\n"            if (defined(getGlobal("${tag}MhapNoTf")) && getGlobal("${tag}MhapNoTf") == 1);
+@@ -464,7 +464,7 @@
+ 
+     print F "  #  Start up the producer.\n";
+     print F "  $javaPath $javaOpt -XX:ParallelGCThreads=",  getGlobal("${tag}mhapThreads"), " -server -Xms", $javaMemory, "m -Xmx", $javaMemory, "m \\\n";
+-    print F "    -jar $cygA \$bin/../share/java/classes/mhap-" . getGlobal("${tag}MhapVersion") . ".jar $cygB \\\n";
++    print F "    -jar $cygA /usr/share/mhap/mhap.jar $cygB \\\n";
+     print F "    --repeat-weight 0.9 --repeat-idf-scale 10 -k $merSize \\\n";
+     print F "    --supress-noise 2 \\\n"  if (defined(getGlobal("${tag}MhapFilterUnique")) && getGlobal("${tag}MhapFilterUnique") == 1);
+     print F "    --no-tf \\\n"            if (defined(getGlobal("${tag}MhapNoTf")) && getGlobal("${tag}MhapNoTf") == 1);


### PR DESCRIPTION
## Involved packages

 - canu


## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [ ] Fix the Packages
  - [x] PKGBUILD
  - [x] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
mhap aligner has been packaged as per arch guidlines and has been added to the repo. This PR adds patches so that canu uses repo packaged 'mhap.jar' instead of bundled precompiled jar