### PR TITLE
alevin-fry: fix build

### DIFF
--- a/BioArchLinux/alevin-fry/PKGBUILD
+++ b/BioArchLinux/alevin-fry/PKGBUILD
@@ -1,19 +1,19 @@
 # Maintainer: bipin kumar <kbipinkumar@pm.me>
 pkgname=alevin-fry
-pkgver=0.8.1
-pkgrel=1
+pkgver=0.8.2
+pkgrel=0
 pkgdesc='A suite of tools for the rapid, accurate and memory-frugal processing single-cell and single-nucleus sequencing data'
 arch=(x86_64)
 depends=('gcc-libs' 'glibc' 'bzip2')
 makedepends=('git' 'rust' 'cmake')
 url='https://alevin-fry.readthedocs.io/en/latest/'
 license=('custom:BSD-3')
+options=(!lto)
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/COMBINE-lab/alevin-fry/archive/refs/tags/v${pkgver}.tar.gz)
-sha256sums=('ecbe927c76a0e084a81ccba4c526a22d3750687d5372625de170b0018de9a5a1')
+sha256sums=('7feaa5b59c6537eee9d1a2a07797f151ba6a50955a969fa1807dcb7aeb357ab1')
 
 prepare() {
     cd ${pkgname}-${pkgver}
-    sed -i 's/thin/off/g' Cargo.toml
     export RUSTUP_TOOLCHAIN=stable
     cargo fetch  --target "$CARCH-unknown-linux-gnu"
 }
@@ -22,14 +22,14 @@ build() {
     cd ${pkgname}-${pkgver}
     export RUSTUP_TOOLCHAIN=stable
     export CARGO_TARGET_DIR=target
-    cargo build --frozen --release --all-features --verbose
+    cargo build --frozen --release --all-features
 }
 
-#check() {
-    #cd ${pkgname}-${pkgver}
-    #export RUSTUP_TOOLCHAIN=stable
-    #cargo test --frozen --all-features
-#}
+check() {
+    cd ${pkgname}-${pkgver}
+    export RUSTUP_TOOLCHAIN=stable
+    cargo test --frozen --all-features
+}
 
 package() {
     cd ${pkgname}-${pkgver}

--- a/BioArchLinux/alevin-fry/lilac.yaml
+++ b/BioArchLinux/alevin-fry/lilac.yaml
@@ -7,6 +7,7 @@ pre_build_script: |
   run_cmd(['updpkgsums'])
 post_build_script: |
   git_pkgbuild_commit()
+  update_aur_repo()
 update_on:
   - source: github
     github: COMBINE-lab/alevin-fry


### PR DESCRIPTION
Disables lto on vendored mimalloc compilation.

Setting `lto = "off"` in `Cargo.toml` most likely only affects the rust compilation, but not the C compilation of mimalloc. The `lto` PKGBUILD option adds the `-flto` flag to `CFLAGS`, so it needs to be disabled. The lto used by the rust compiler isn't a problem.