### PR TITLE
cytoscape: fix jdk version

### DIFF
--- a/BioArchLinux/cytoscape/cytoscape
+++ b/BioArchLinux/cytoscape/cytoscape
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 unset JAVA_HOME
-export PATH="/usr/lib/jvm/java-11-openjdk/bin:$PATH"
+export PATH="/usr/lib/jvm/java-17-openjdk/bin:$PATH"
 exec /opt/cytoscape/cytoscape.sh $@


### PR DESCRIPTION
## Involved packages

 - cytoscape

## Involved issue

fix jdk version from 11 to 17



## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [x] Fix the Packages
  - [ ] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
