### PR TITLE
veusz: chane source to pypi

### DIFF
--- a/BioArchLinux/veusz/PKGBUILD
+++ b/BioArchLinux/veusz/PKGBUILD
@@ -19,7 +19,7 @@ optdepends=('python-h5py:  HDF5 support'
             'python-iminuit: improved fitting'
             'python-astropy: VO table import and FITS import'
             'ghostscript: for EPS/PS output')
-source=("https://github.com/veusz/veusz/releases/download/veusz-${pkgver}/veusz-${pkgver}.tar.gz")
+source=("${pkgname}-${pkgver}.tar.gz::https://files.pythonhosted.org/packages/source/${_module::1}/$_module/${_module}-$pkgver.tar.gz")
 sha256sums=('c2171ac45e4b30424d8fc35261e2e99dbe6e25ba1197ebc24355b106b26395d1')
 
 build() {

--- a/BioArchLinux/veusz/lilac.yaml
+++ b/BioArchLinux/veusz/lilac.yaml
@@ -1,14 +1,13 @@
-build_prefix: extra-x86_64
 maintainers:
-- github: kiri2002
-  email: kiri@vern.cc
+  - github: kiri2002
+    email: kiri@vern.cc
+build_prefix: extra-x86_64
 pre_build_script: |
   update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
   run_cmd(['updpkgsums'])
 post_build_script: |
   git_pkgbuild_commit()
 update_on:
-- regex: class=\"Link--primary\">veusz-(.*?)</a></h2>
-  source: regex
-  url: https://github.com/veusz/veusz/tags
-- alias: python
+  - source: pypi
+    pypi: veusz
+  - alias: python


### PR DESCRIPTION
## Involved packages

 - veusz

## Involved issue

change source from github to pypi for elegant and easy auto-update 

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [x] Fix the Packages
  - [x] PKGBUILD
  - [x] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
