### PR TITLE
tbtools: Add optdeps and change update source

### DIFF
--- a/BioArchLinux/tbtools/PKGBUILD
+++ b/BioArchLinux/tbtools/PKGBUILD
@@ -3,18 +3,29 @@
 
 pkgname=tbtools
 _pkgname=TBtools
-pkgver=2023.07.14
+pkgver=2.000
 pkgrel=1
 pkgdesc='GUI/CommandLine Tool Box for biologistists to utilize NGS data. https://doi.org/10.1016/j.molp.2020.06.009'
 arch=('x86_64')
 url='https://github.com/CJ-Chen/TBtools'
-license=('custom')
-depends=('java-runtime' 'bash')
-makedepends=('git' 'unzip')
-source=("git+https://github.com/CJ-Chen/TBtools.git"
+license=('unknown')
+depends=('java-runtime'
+         'bash')
+makedepends=('git'
+             'unzip')
+optdepends=('blast+: BLAST support'
+            'diamond: quick blast(needed in quick MCScanx scan) support'
+            'mcscanx: collinear scan support'
+            'hmmer: HMM Search support'
+            'muscle: align support'
+            'trimal: large scale align support'
+            'iqtree: maximum likelihood phylogenomic tree support'
+            'kaks_calculator: kaks calculate support'
+            )
+source=("git+https://github.com/Kiri2002/TBtools.git"
         "$pkgname.desktop"
         "$pkgname.sh")
-sha256sums=('SKIP'
+sha256sums=('4ae4527d62953d48794e9b7855f92891051c041cfd18b1cb3a5c2bb4ea561277'
             '6fbce89df42435fc2d618a7f0600077e872c751d70547041dad639e68447fb7d'
             '04367e92b51a3717a38c76f07892282458ed9aaa7c3f47ca47ef62de1c30c90f')
 pkgver() {

--- a/BioArchLinux/tbtools/lilac.yaml
+++ b/BioArchLinux/tbtools/lilac.yaml
@@ -1,9 +1,13 @@
 maintainers:
-- github: kiri2002
-  email: kiri@vern.cc
+  - github: kiri2002
+    email: kiri@vern.cc
 build_prefix: extra-x86_64
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+  run_cmd(['updpkgsums'])
 post_build_script: |
   git_pkgbuild_commit()
 update_on:
-- source: github
-  github: CJ-Chen/TBtools
+  - source: github
+    github: Kiri2002/TBtools
+    use_max_tag: true


### PR DESCRIPTION
## Involved packages

 - tbtools

## Involved issue
-  fix PKGBUILD and lilac.yaml

## Details

1. Add the opt-deps
2. Change the license to 'unknown' as archwiki PKGBUILD said for no license released by cj-chen(only MIT in 2016 and now just close . seehttps://github.com/CJ-Chen/TBtools-Manual/blob/master/LICENSE)
3. Change the update-repo to Kiri2002/tbtools due to cj-chen refuse update jar, and no linux version release, and bad tags-verisons. In Kiri2002/tbtools, I will always update the jar and fix tags.

<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [ ] Fix the Packages
  - [ ] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
