### PR TITLE
tcoffee: fix lilac.yaml

### DIFF
--- a/BioArchLinux/tcoffee/lilac.yaml
+++ b/BioArchLinux/tcoffee/lilac.yaml
@@ -1,14 +1,13 @@
 build_prefix: extra-x86_64
 maintainers:
-- github: kiri2002
-  email: kiri@vern.cc
+  - github: kiri2002
+    email: kiri@vern.cc
 pre_build_script: |
   update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
   run_cmd(['updpkgsums'])
 post_build_script: |
   git_pkgbuild_commit()
 update_on:
-  - source: github
-    github: cbcrg/tcoffee
-    use_max_tag: true
-    prefix: 'Version_'
+- regex: Version_(.*?).tar.gz
+  source: regex
+  url: https://github.com/cbcrg/tcoffee/tags


### PR DESCRIPTION
## Involved packages

 - tcoffee

## Involved issue

lilac can't get right newest-tags because bad tags-writting, i change to regex
[tags here](https://github.com/cbcrg/tcoffee/tags)



## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [x] Fix the Packages
  - [ ] PKGBUILD
  - [x] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
