### PR TITLE
veusz: fix lilac.yaml

### DIFF
--- a/BioArchLinux/veusz/lilac.yaml
+++ b/BioArchLinux/veusz/lilac.yaml
@@ -3,12 +3,12 @@ maintainers:
     email: kiri@vern.cc
 build_prefix: extra-x86_64
 pre_build_script: |
-  update_pkgver_and_pkgrel(_G.newver.lstrip('veusz-'))
+  update_pkgver_and_pkgrel(_G.newver)
   run_cmd(['updpkgsums'])
 post_build_script: |
   git_pkgbuild_commit()
 update_on:
   - source: github
     github: veusz/veusz
-    use_max_tag: true
+    use_latest_release: true
     prefix: 'veusz-'


### PR DESCRIPTION
## Involved packages

 -  veusz

## Involved issue

 - fix lilac

## Details
Before:
 use_max_tag got two(need 3.6.2) :
```
'update_info': [['3.6.2', 'veusz3d-2.1.101']]
```
err:
```
==> ERROR: pkgver is not allowed to contain colons, forward slashes, hyphens or whitespace.
```
Fixed:
```
use_latest_release
```

<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [x] Fix the Packages
  - [ ] PKGBUILD
  - [x] lilac.yaml
  - [ ] lilac.py
- [x] Would like to continue to work with us

## Additional Note
