### PR TITLE
Add jaspRobustTTests module

### DIFF
--- a/BioArchLinux/jasp-desktop/lilac.yaml
+++ b/BioArchLinux/jasp-desktop/lilac.yaml
@@ -14,6 +14,7 @@ repo_depends:
   - "r-jaspanova"
   - "r-jaspmixedmodels"
   - "r-jaspregression"
+  - "r-jasprobustttests"
   - "r-jaspfrequencies"
   - "r-jaspfactor"
   - "r-jaspaudit"

--- a/BioArchLinux/r-jasprobustttests/PKGBUILD
+++ b/BioArchLinux/r-jasprobustttests/PKGBUILD
@@ -1,0 +1,32 @@
+#Maintainer: sukanka <su975853527 AT gmail.com>
+_pkgname=jaspRobustTTests
+_pkgver=0.18.0
+pkgname=r-${_pkgname,,}
+pkgver=0.18.0
+pkgrel=1
+pkgdesc="A robust T-Test module for JASP"
+arch=('any')
+url="https://github.com/jasp-stats/${_pkgname}"
+license=('GPL')
+depends=(
+  r
+  r-ggplot2
+  r-robtt
+  r-jaspbase
+  r-jaspgraphs
+)
+groups=(r-jasp r-jaspextra)
+source=("${_pkgname}_${_pkgver}.tar.gz::${url}/archive/refs/tags/v${_pkgver}.tar.gz")
+sha256sums=('e3fad53e2fa96259a4c7adacfa5f2b8a578839b5bbb3bee963aba7b208192bf9')
+
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
+  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
+}

--- a/BioArchLinux/r-jasprobustttests/lilac.yaml
+++ b/BioArchLinux/r-jasprobustttests/lilac.yaml
@@ -1,0 +1,24 @@
+maintainers:
+  - github: sukanka
+    email: su975853527@gmail.com
+build_prefix: extra-x86_64
+post_build_script: |
+  git_pkgbuild_commit()
+  update_aur_repo()
+pre_build_script: |
+  for line in edit_file('PKGBUILD'):
+    if line.startswith('_pkgver='):
+      line = f'_pkgver={_G.newver}'
+    print(line)
+  update_pkgver_and_pkgrel(_G.newver.replace(':', '.').replace('-', '.'))
+repo_depends:
+  - r-ggplot2
+  - r-robtt
+  - r-jaspbase
+  - r-jaspgraphs
+update_on:
+  - source: github
+    github: jasp-stats/jaspRobustTTests
+    use_max_tag: true
+    prefix: v
+  - alias: r


### PR DESCRIPTION
## Involved packages

 - jaspRobustTTests 

## Involved issue

N/A

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [x] Provide New Package
- [ ] Fix the Packages
  - [ ] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [x] Would like to continue to work with us

## Additional Note

This is a new modules for jaspDesktop package, I just added it according to the fixed format, not tested.
request a review from @sukanka with thanks.

Another suggestion: If the build system is able to read the submodule from the main repository for example (a [.gitmodules](https://github.com/jasp-stats/jasp-desktop/blob/stable/.gitmodules) file from [JASP repo](https://github.com/jasp-stats/jasp-desktop/tree/stable/Modules) ), without any tag tracking and manual addition, the build system is always able to read the HEAD of the current reference of the git submodule.As such, this will also available for any git repository with submodules:-)

great job BioArchLinux team!

