### PR TITLE
snpeff: use update_on to get SnpSift version

### DIFF
--- a/BioArchLinux/snpeff/lilac.py
+++ b/BioArchLinux/snpeff/lilac.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
-import requests
-import fileinput
 from lilaclib import *
 
-def get_latest_tag(owner, repo):
-    url = f"https://api.github.com/repos/{owner}/{repo}/tags"
-    response = requests.get(url)
-    response.raise_for_status()
-    tags = response.json()
-    latest_tag = tags[0]["name"].lstrip("v")
-    return latest_tag
-
 def pre_build():    
-    latest_tag = get_latest_tag("pcingola", "SnpSift")
     for line in edit_file('PKGBUILD'):
         if line.startswith('_pkgver2='):
-            current_tag = line.split("=")[1].strip()
-            if latest_tag > current_tag:
-                line = f'_pkgver2={latest_tag}'
+            line = f'_pkgver2={_G.newvers[1]}'
         print(line)
 
-    update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+    update_pkgver_and_pkgrel(_G.newver)

--- a/BioArchLinux/snpeff/lilac.yaml
+++ b/BioArchLinux/snpeff/lilac.yaml
@@ -2,8 +2,6 @@ maintainers:
   - github: kbipinkumar
     email: kbipinkumar@pm.me
 build_prefix: extra-x86_64
-pre_build_script: |
-  run_cmd(['updpkgsums'])
 post_build_script: |
   git_pkgbuild_commit()
   update_aur_repo()
@@ -11,4 +9,8 @@ update_on:
 - source: github
   github: pcingola/SnpEff
   use_max_tag: true
-  prefix: 'v'
+  prefix: v
+- source: github
+  github: pcingola/SnpSift
+  use_max_tag: true
+  prefix: v


### PR DESCRIPTION
This fetches the SnpSift version using nvchecker. The benefit of this is simpler code, and also lilac will rebuild the package when SnpSift is updated.

Some other notes:
- If both `pre_build` function in `lilac.py` and a `pre_build_script` in `lilac.yaml` are defined, only one of them is run. I think only the `pre_build_script` is effective in this case.
- `update_pkgver_and_pkgrel` runs `updpkgsums` automatically.
- `.lstrip('v')` is unnecessary for the `update_pkgver_and_pkgrel` call, because the `prefix: v` nvchecker option already strips the `v` prefix.
- Comparing the version tags as strings doesn't work. For example, `"10.1" < "5.1"` is `True` in python. It's better to let nvchecker decide what is the max tag.