### PR TITLE
minimap2: harden binaries and add libs to package

### DIFF
--- a/BioArchLinux/minimap2/PKGBUILD
+++ b/BioArchLinux/minimap2/PKGBUILD
@@ -13,11 +13,11 @@ provides=('minimap2-lite' 'sdust' 'libminimap2.so')
 source=("${pkgname}-${pkgver}.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz"
         "hardening.patch")
 sha256sums=('f4c8c3459c7b87e9de6cbed7de019b48d9337c2e46b87ba81b9f72d889420b3c'
-            '792146de76e9003cccb429623eae715ab0349396eafda3001bdec940323e9356')
+            'ff10a6b715db2e08add52b371842778f855cb4edc9f7fc373c6e1b670ef1415f')
 
 prepare() {
-  # Add hardening flags for binaries
   cd "${pkgname}-${pkgver}"
+  # Add hardening flags for binaries
   patch -p1 < "${srcdir}"/hardening.patch
 }
 
@@ -31,14 +31,14 @@ build() {
 package() {
   cd "${pkgname}-${pkgver}"
   install -Dm644 LICENSE.txt "${pkgdir}"/usr/share/licenses/${pkgname}/LICENSE
-  install -Dm644 libminimap2.so "${pkgdir}"/usr/lib/libminimap2.so
+  install -Dm755 libminimap2.so "${pkgdir}"/usr/lib/libminimap2.so
   install -Dm755 ${pkgname} "${pkgdir}"/usr/bin/${pkgname}
   install -Dm755 minimap2-lite "${pkgdir}"/usr/bin/minimap2-lite
   install -Dm755 sdust "${pkgdir}"/usr/bin/sdust
   # install Manpages
   install -Dm644 -t "$pkgdir/usr/share/man/man1" minimap2.1
   # install test Data
-  install -d ${pkgdir}/usr/share/${pkgname}/test
+  install -d "${pkgdir}"/usr/share/${pkgname}/test
   cd test
   for file in *; do
     install -Dm644 "$file" "${pkgdir}"/usr/share/${pkgname}/test/"${file}"

--- a/BioArchLinux/minimap2/PKGBUILD
+++ b/BioArchLinux/minimap2/PKGBUILD
@@ -9,20 +9,16 @@ arch=('x86_64')
 url="https://github.com/lh3/${pkgname}"
 license=('MIT')
 depends=('zlib' 'glibc')
-provides=('minimap2-lite' 'sdust')
-source=("${pkgname}-${pkgver}.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('f4c8c3459c7b87e9de6cbed7de019b48d9337c2e46b87ba81b9f72d889420b3c')
+provides=('minimap2-lite' 'sdust' 'libminimap2.so')
+source=("${pkgname}-${pkgver}.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz"
+        "hardening.patch")
+sha256sums=('f4c8c3459c7b87e9de6cbed7de019b48d9337c2e46b87ba81b9f72d889420b3c'
+            '792146de76e9003cccb429623eae715ab0349396eafda3001bdec940323e9356')
 
 prepare() {
-  cd "${pkgname}-${pkgver}"
   # Add hardening flags for binaries
-  sed -i '1s/CFLAGS=/CFLAGS+=/' Makefile
-  sed -i '2s/CPPFLAGS=/CPPFLAGS+=/' Makefile
-  sed -i '52s/$(LIBS)/$(LIBS) $(LDFLAGS)/' Makefile
-  sed -i '55s/$(LIBS)/$(LIBS) $(LDFLAGS)/' Makefile
-  sed -i '61s/-lz/-lz $(LDFLAGS)/' Makefile
-  sed -i '57a\\t\ \trm -f "$@"' Makefile
-  sed -i '59s/-csru/csrD/' Makefile
+  cd "${pkgname}-${pkgver}"
+  patch -p1 < "${srcdir}"/hardening.patch
 }
 
 build() {
@@ -35,7 +31,7 @@ build() {
 package() {
   cd "${pkgname}-${pkgver}"
   install -Dm644 LICENSE.txt "${pkgdir}"/usr/share/licenses/${pkgname}/LICENSE
-  install -Dm644 libminimap2.a "${pkgdir}"/usr/lib/libminimap2.a
+  install -Dm644 libminimap2.so "${pkgdir}"/usr/lib/libminimap2.so
   install -Dm755 ${pkgname} "${pkgdir}"/usr/bin/${pkgname}
   install -Dm755 minimap2-lite "${pkgdir}"/usr/bin/minimap2-lite
   install -Dm755 sdust "${pkgdir}"/usr/bin/sdust

--- a/BioArchLinux/minimap2/PKGBUILD
+++ b/BioArchLinux/minimap2/PKGBUILD
@@ -10,7 +10,7 @@ url="https://github.com/lh3/${pkgname}"
 license=('MIT')
 depends=('zlib' 'glibc')
 provides=('minimap2-lite' 'sdust')
-source=("${pkgver}.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+source=("${pkgname}-${pkgver}.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('f4c8c3459c7b87e9de6cbed7de019b48d9337c2e46b87ba81b9f72d889420b3c')
 
 prepare() {
@@ -34,15 +34,17 @@ build() {
 
 package() {
   cd "${pkgname}-${pkgver}"
-  install -Dm644 LICENSE.txt "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
-  install -Dm644 libminimap2.a "${pkgdir}/usr/lib/libminimap2.a"
-  install -Dm755 ${pkgname} "${pkgdir}/usr/bin/${pkgname}"
-  install -Dm755 minimap2-lite "${pkgdir}/usr/bin/minimap2-lite"
-  install -Dm755 sdust "${pkgdir}/usr/bin/sdust"
-  # install test Data
-  install -d ${pkgdir}/usr/share/${pkgname}/
-  cp -r test/ ${pkgdir}/usr/share/${pkgname}/
+  install -Dm644 LICENSE.txt "${pkgdir}"/usr/share/licenses/${pkgname}/LICENSE
+  install -Dm644 libminimap2.a "${pkgdir}"/usr/lib/libminimap2.a
+  install -Dm755 ${pkgname} "${pkgdir}"/usr/bin/${pkgname}
+  install -Dm755 minimap2-lite "${pkgdir}"/usr/bin/minimap2-lite
+  install -Dm755 sdust "${pkgdir}"/usr/bin/sdust
   # install Manpages
-  mkdir -p ${pkgdir}/usr/share/man/man1/
-  cp  minimap2.1 ${pkgdir}/usr/share/man/man1/minimap2.1
+  install -Dm644 -t "$pkgdir/usr/share/man/man1" minimap2.1
+  # install test Data
+  install -d ${pkgdir}/usr/share/${pkgname}/test
+  cd test
+  for file in *; do
+    install -Dm644 "$file" "${pkgdir}"/usr/share/${pkgname}/test/"${file}"
+  done
 }

--- a/BioArchLinux/minimap2/PKGBUILD
+++ b/BioArchLinux/minimap2/PKGBUILD
@@ -3,23 +3,46 @@
 
 pkgname=minimap2
 pkgver=2.26
-pkgrel=1
+pkgrel=2
 pkgdesc='A versatile pairwise aligner for genomic and spliced nucleotide sequences. https://doi.org/10.1093/bioinformatics/bty191'
 arch=('x86_64')
 url="https://github.com/lh3/${pkgname}"
 license=('MIT')
-depends=(zlib)
-provides=()
+depends=('zlib' 'glibc')
+provides=('minimap2-lite' 'sdust')
 source=("${pkgver}.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('f4c8c3459c7b87e9de6cbed7de019b48d9337c2e46b87ba81b9f72d889420b3c')
+
+prepare() {
+  cd "${pkgname}-${pkgver}"
+  # Add hardening flags for binaries
+  sed -i '1s/CFLAGS=/CFLAGS+=/' Makefile
+  sed -i '2s/CPPFLAGS=/CPPFLAGS+=/' Makefile
+  sed -i '52s/$(LIBS)/$(LIBS) $(LDFLAGS)/' Makefile
+  sed -i '55s/$(LIBS)/$(LIBS) $(LDFLAGS)/' Makefile
+  sed -i '61s/-lz/-lz $(LDFLAGS)/' Makefile
+  sed -i '57a\\t\ \trm -f "$@"' Makefile
+  sed -i '59s/-csru/csrD/' Makefile
+}
+
 build() {
   cd "${pkgname}-${pkgver}"
-  make
+  # Build all binaries
+  make extra
+
 }
 
 package() {
   cd "${pkgname}-${pkgver}"
   install -Dm644 LICENSE.txt "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
-  install -Dm644 ${pkgname} "${pkgdir}/usr/bin/${pkgname}"
-  chmod +x "${pkgdir}/usr/bin/${pkgname}"
+  install -Dm644 libminimap2.a "${pkgdir}/usr/lib/libminimap2.a"
+  install -Dm755 ${pkgname} "${pkgdir}/usr/bin/${pkgname}"
+  install -Dm755 minimap2-lite "${pkgdir}/usr/bin/minimap2-lite"
+  install -Dm755 sdust "${pkgdir}/usr/bin/sdust"
+  # install test Data
+  install -d ${pkgdir}/usr/share/${pkgname}/
+  cp -r test/ ${pkgdir}/usr/share/${pkgname}/
+  # install Manpages
+  mkdir -p ${pkgdir}/usr/share/man/man1/
+  cp  minimap2.1 ${pkgdir}/usr/share/man/man1/minimap2.1
 }

--- a/BioArchLinux/minimap2/hardening.patch
+++ b/BioArchLinux/minimap2/hardening.patch
@@ -1,11 +1,11 @@
 --- minimap2-2.26.orig/Makefile	2023-04-29 21:51:09.000000000 +0530
-+++ minimap2-2.26.new/Makefile	2023-10-21 13:31:34.438714294 +0530
++++ minimap2-2.26.new/Makefile	2023-10-21 16:56:41.816040016 +0530
 @@ -1,5 +1,6 @@
 -CFLAGS=		-g -Wall -O2 -Wc++-compat #-Wextra
 -CPPFLAGS=	-DHAVE_KALLOC
 +CFLAGS+=		-g -Wall -fPIC -pie -O2 -Wc++-compat #-Wextra
 +CPPFLAGS+=	-DHAVE_KALLOC
-+LDFLAGS += -shared -pie
++LDFLAGS += -pie
  INCLUDES=
  OBJS=		kthread.o kalloc.o misc.o bseq.o sketch.o sdust.o options.o index.o \
  			lchain.o align.o hit.o seed.o map.o format.o pe.o esterr.o splitidx.o \
@@ -25,21 +25,21 @@
 -minimap2:main.o libminimap2.a
 -		$(CC) $(CFLAGS) main.o -o $@ -L. -lminimap2 $(LIBS)
 +$(LIBRARY): $(OBJS)
-+		$(CC) $(CFLAGS) $(LDFLAGS) -shared -Wl,-soname,lib$(NAME).so -lm -lz $^ -o $@
++		$(CC) $(LDFLAGS) -shared -Wl,-soname,lib$(NAME).so $^ -lm -lz -o $@
  
 -minimap2-lite:example.o libminimap2.a
 -		$(CC) $(CFLAGS) $< -o $@ -L. -lminimap2 $(LIBS)
 +minimap2:main.o libminimap2.so
-+		$(CC) $(CFLAGS) main.o -o $@ -L. -lminimap2 $(LIBS) $(LDFLAGS)
++		$(CC) $(LDFLAGS) main.o -o $@ -L. -lminimap2 $(LIBS)
  
 -libminimap2.a:$(OBJS)
 -		$(AR) -csru $@ $(OBJS)
 +minimap2-lite:example.o libminimap2.so
-+		$(CC) $(CFLAGS) $< -o $@ -L. -lminimap2 $(LIBS) $(LDFLAGS)
++		$(CC) $(LDFLAGS) $< -o $@ -L. -lminimap2 $(LIBS)
  
  sdust:sdust.c kalloc.o kalloc.h kdq.h kvec.h kseq.h ketopt.h sdust.h
 -		$(CC) -D_SDUST_MAIN $(CFLAGS) $< kalloc.o -o $@ -lz
-+		$(CC) -D_SDUST_MAIN $(CFLAGS) $< kalloc.o -o $@ -lz $(LDFLAGS)
++		$(CC) $(LDFLAGS) -D_SDUST_MAIN $(CFLAGS) $< kalloc.o -o $@ -lz
  
  # SSE-specific targets on x86/x86_64
  

--- a/BioArchLinux/minimap2/hardening.patch
+++ b/BioArchLinux/minimap2/hardening.patch
@@ -1,0 +1,45 @@
+--- minimap2-2.26.orig/Makefile	2023-04-29 21:51:09.000000000 +0530
++++ minimap2-2.26.new/Makefile	2023-10-21 13:31:34.438714294 +0530
+@@ -1,5 +1,6 @@
+-CFLAGS=		-g -Wall -O2 -Wc++-compat #-Wextra
+-CPPFLAGS=	-DHAVE_KALLOC
++CFLAGS+=		-g -Wall -fPIC -pie -O2 -Wc++-compat #-Wextra
++CPPFLAGS+=	-DHAVE_KALLOC
++LDFLAGS += -shared -pie
+ INCLUDES=
+ OBJS=		kthread.o kalloc.o misc.o bseq.o sketch.o sdust.o options.o index.o \
+ 			lchain.o align.o hit.o seed.o map.o format.o pe.o esterr.o splitidx.o \
+@@ -40,6 +41,8 @@
+ 
+ .PHONY:all extra clean depend
+ .SUFFIXES:.c .o
++NAME := minimap2
++LIBRARY := lib$(NAME).so
+ 
+ .c.o:
+ 		$(CC) -c $(CFLAGS) $(CPPFLAGS) $(INCLUDES) $< -o $@
+@@ -48,17 +51,17 @@
+ 
+ extra:all $(PROG_EXTRA)
+ 
+-minimap2:main.o libminimap2.a
+-		$(CC) $(CFLAGS) main.o -o $@ -L. -lminimap2 $(LIBS)
++$(LIBRARY): $(OBJS)
++		$(CC) $(CFLAGS) $(LDFLAGS) -shared -Wl,-soname,lib$(NAME).so -lm -lz $^ -o $@
+ 
+-minimap2-lite:example.o libminimap2.a
+-		$(CC) $(CFLAGS) $< -o $@ -L. -lminimap2 $(LIBS)
++minimap2:main.o libminimap2.so
++		$(CC) $(CFLAGS) main.o -o $@ -L. -lminimap2 $(LIBS) $(LDFLAGS)
+ 
+-libminimap2.a:$(OBJS)
+-		$(AR) -csru $@ $(OBJS)
++minimap2-lite:example.o libminimap2.so
++		$(CC) $(CFLAGS) $< -o $@ -L. -lminimap2 $(LIBS) $(LDFLAGS)
+ 
+ sdust:sdust.c kalloc.o kalloc.h kdq.h kvec.h kseq.h ketopt.h sdust.h
+-		$(CC) -D_SDUST_MAIN $(CFLAGS) $< kalloc.o -o $@ -lz
++		$(CC) -D_SDUST_MAIN $(CFLAGS) $< kalloc.o -o $@ -lz $(LDFLAGS)
+ 
+ # SSE-specific targets on x86/x86_64
+ 

--- a/BioArchLinux/minimap2/lilac.yaml
+++ b/BioArchLinux/minimap2/lilac.yaml
@@ -17,13 +17,3 @@ update_on:
     repo: core
     provided: libz.so
     strip_release: true
-  - source: alpm
-    alpm: glibc
-    repo: core
-    provided: libm.so
-    strip_release: true
-  - source: alpm
-    alpm: glibc
-    repo: core
-    provided: libc.so
-    strip_release: true

--- a/BioArchLinux/minimap2/lilac.yaml
+++ b/BioArchLinux/minimap2/lilac.yaml
@@ -12,3 +12,18 @@ update_on:
     github: lh3/minimap2
     use_max_tag: true
     prefix: 'v'
+  - source: alpm
+    alpm: zlib
+    repo: core
+    provided: libz.so
+    strip_release: true
+  - source: alpm
+    alpm: glibc
+    repo: core
+    provided: libm.so
+    strip_release: true
+  - source: alpm
+    alpm: glibc
+    repo: core
+    provided: libc.so
+    strip_release: true


### PR DESCRIPTION
## Involved packages

 - minimap2

## Involved issue

NA

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [x] Fix the Packages
  - [x] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
1. build all the binaries as included in Makefile
2. Binaries are hardened with recommended build flags as per archlinux wiki
3. included library files in the package archive so that same can be used for building other packages
4. include manpages and test files from upstream into package archive