### PR TITLE
Fix usage instructions to prevent partial upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ install GPG keyring to use bioarchlinux
 
 update the database
 ```
-# pacman -Syy
+# pacman -Syu
 ```
 
 install any package


### PR DESCRIPTION
Fix the BioArchLinux setup instructions in README.md to not cause partial upgrades.

On Arch Linux, [partial upgrades are unsupported](https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported) and can break the system. Specifically, running `pacman -Sy` without the `u` option can lead to a partial upgrade, if new packages are installed afterwards without running `pacman -Su`. To prevent this, change the instructions to do `-Syu` instead.

This also removes the second `y` option, since it's unnecessary and wastes mirror bandwidth. Pacman can automatically figure out which databases need to be downloaded.