### PR TITLE
python-pyfastani: remove `fastani` from `depends`

### DIFF
--- a/BioArchLinux/python-pyfastani/PKGBUILD
+++ b/BioArchLinux/python-pyfastani/PKGBUILD
@@ -9,7 +9,7 @@ url="https://github.com/althonos/${_name}"
 arch=('i686' 'pentium4' 'x86_64' 'arm' 'armv6h' 'armv7h' 'aarch64')
 license=("MIT")
 makedepends=('python-setuptools' 'cython' 'python-build' 'python-installer' 'python-wheel')
-depends=('python' 'fastani' 'gcc-libs' 'glibc')
+depends=('python' 'gcc-libs' 'glibc')
 source=("https://files.pythonhosted.org/packages/source/${_name::1}/$_name/$_name-$pkgver.tar.gz")
 sha256sums=('44d86cbe8581d4891748ebe9851ae0a0c27489bb9f77728131415ed6b90cc35a')
 


### PR DESCRIPTION
## Involved packages

 - `python-pyfastani`

## Details

- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [x] Fix the Packages
  - [x] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [x] Would like to continue to work with us

## Additional Note

`fastani` is listed as a dependency of `python-pyfastani`, but the Python package comes batteries-included and doesn't require the original FastANI binary.
