### PR TITLE
python-pyhmmer: add package

### DIFF
--- a/BioArchLinux/python-pyhmmer/PKGBUILD
+++ b/BioArchLinux/python-pyhmmer/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Martin Larralde <martin.larralde@embl.de>
+
+_name=pyhmmer
+pkgname=python-${_name}
+pkgver=0.10.10
+pkgrel=1
+pkgdesc="Cython bindings to HMMER3. https://doi.org/10.1093/bioinformatics/btad214"
+url="https://github.com/althonos/pyhmmer"
+arch=('i686' 'x86_64' 'arm' 'armv6h' 'armv7h' 'aarch64')
+license=("MIT")
+makedepends=('python-setuptools' 'cython' 'python-build' 'python-installer' 'python-wheel')
+depends=('python' 'glibc' 'python-psutil')
+source=("https://files.pythonhosted.org/packages/source/${_name::1}/$_name/$_name-$pkgver.tar.gz")
+noextract=()
+sha256sums=('2c7bda6f5c5520d708c7886a6303229a275791fe4e7074a716dbb63fec16804b')
+
+build() {
+    cd "${srcdir}/${_name}-${pkgver}"
+    python -m build --wheel --no-isolation
+}
+
+check() {
+    local pyver=$(python -c 'import sys; print(sys.implementation.cache_tag)')
+    local machine=$(python -c 'import platform; print(platform.machine())')
+    cd "${srcdir}/${_name}-${pkgver}/build/lib.linux-${machine}-${pyver}"
+    python -m unittest ${_name}.tests
+}
+
+package() {
+    local abitag=$(python -c 'import sys; print(*sys.version_info[:2], sep="")')
+    local machine=$(python -c 'import platform; print(platform.machine())')
+    python -m installer --destdir="$pkgdir" "${srcdir}/${_name}-${pkgver}/dist/${_name}-${pkgver}-cp${abitag}-cp${abitag}-linux_${machine}.whl"
+    install -Dm644  ${srcdir}/${_name}-${pkgver}/COPYING "$pkgdir/usr/share/licenses/$pkgname/COPYING"
+}

--- a/BioArchLinux/python-pyhmmer/PKGBUILD
+++ b/BioArchLinux/python-pyhmmer/PKGBUILD
@@ -29,5 +29,5 @@ package() {
     local abitag=$(python -c 'import sys; print(*sys.version_info[:2], sep="")')
     local machine=$(python -c 'import platform; print(platform.machine())')
     python -m installer --destdir="$pkgdir" "${srcdir}/${_name}-${pkgver}/dist/${_name}-${pkgver}-cp${abitag}-cp${abitag}-linux_${machine}.whl"
-    install -Dm644  ${srcdir}/${_name}-${pkgver}/COPYING "$pkgdir/usr/share/licenses/$pkgname/COPYING"
+    install -Dm644  "${srcdir}/${_name}-${pkgver}/COPYING" "$pkgdir/usr/share/licenses/$pkgname/COPYING"
 }

--- a/BioArchLinux/python-pyhmmer/PKGBUILD
+++ b/BioArchLinux/python-pyhmmer/PKGBUILD
@@ -10,24 +10,29 @@ url="https://github.com/althonos/pyhmmer"
 license=("MIT")
 depends=('python' 'glibc' 'python-psutil')
 makedepends=('python-setuptools' 'cython' 'python-build' 'python-installer' 'python-wheel')
-source=("https://files.pythonhosted.org/packages/source/${_name::1}/$_name/$_name-$pkgver.tar.gz")
-sha256sums=('2c7bda6f5c5520d708c7886a6303229a275791fe4e7074a716dbb63fec16804b')
+source=("git+https://github.com/althonos/pyhmmer.git#tag=v$pkgver")
+sha256sums=('SKIP')
+
+prepare() {
+    cd "${srcdir}/${_name}"
+    git submodule update --init --recursive --remote
+}
 
 build() {
-    cd "${srcdir}/${_name}-${pkgver}"
+    cd "${srcdir}/${_name}"
     python -m build --wheel --no-isolation
 }
 
 check() {
     local pyver=$(python -c 'import sys; print(sys.implementation.cache_tag)')
     local machine=$(python -c 'import platform; print(platform.machine())')
-    cd "${srcdir}/${_name}-${pkgver}/build/lib.linux-${machine}-${pyver}"
+    cd "${srcdir}/${_name}/build/lib.linux-${machine}-${pyver}"
     python -m unittest ${_name}.tests
 }
 
 package() {
     local abitag=$(python -c 'import sys; print(*sys.version_info[:2], sep="")')
     local machine=$(python -c 'import platform; print(platform.machine())')
-    python -m installer --destdir="$pkgdir" "${srcdir}/${_name}-${pkgver}/dist/${_name}-${pkgver}-cp${abitag}-cp${abitag}-linux_${machine}.whl"
-    install -Dm644  "${srcdir}/${_name}-${pkgver}/COPYING" "$pkgdir/usr/share/licenses/$pkgname/COPYING"
+    python -m installer --destdir="$pkgdir" "${srcdir}/${_name}/dist/${_name}-${pkgver}-cp${abitag}-cp${abitag}-linux_${machine}.whl"
+    install -Dm644  "${srcdir}/${_name}/COPYING" "$pkgdir/usr/share/licenses/$pkgname/COPYING"
 }

--- a/BioArchLinux/python-pyhmmer/PKGBUILD
+++ b/BioArchLinux/python-pyhmmer/PKGBUILD
@@ -5,13 +5,12 @@ pkgname=python-${_name}
 pkgver=0.10.10
 pkgrel=1
 pkgdesc="Cython bindings to HMMER3. https://doi.org/10.1093/bioinformatics/btad214"
-url="https://github.com/althonos/pyhmmer"
 arch=('i686' 'x86_64' 'arm' 'armv6h' 'armv7h' 'aarch64')
+url="https://github.com/althonos/pyhmmer"
 license=("MIT")
-makedepends=('python-setuptools' 'cython' 'python-build' 'python-installer' 'python-wheel')
 depends=('python' 'glibc' 'python-psutil')
+makedepends=('python-setuptools' 'cython' 'python-build' 'python-installer' 'python-wheel')
 source=("https://files.pythonhosted.org/packages/source/${_name::1}/$_name/$_name-$pkgver.tar.gz")
-noextract=()
 sha256sums=('2c7bda6f5c5520d708c7886a6303229a275791fe4e7074a716dbb63fec16804b')
 
 build() {

--- a/BioArchLinux/python-pyhmmer/lilac.yaml
+++ b/BioArchLinux/python-pyhmmer/lilac.yaml
@@ -3,11 +3,12 @@ maintainers:
     email: althonosdev@gmail.com
 build_prefix: extra-x86_64
 pre_build_script: |
-  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
-  run_cmd(['updpkgsums'])
+  update_pkgver_and_pkgrel(_G.newver)
 post_build_script: |
   git_pkgbuild_commit()
 update_on:
-  - source: pypi
-    pypi: pyhmmer
+  - source: github
+    pypi: althonos/pyhmmer
+    use_max_tag: true
+    prefix: 'v'
   - alias: python

--- a/BioArchLinux/python-pyhmmer/lilac.yaml
+++ b/BioArchLinux/python-pyhmmer/lilac.yaml
@@ -7,8 +7,6 @@ pre_build_script: |
   run_cmd(['updpkgsums'])
 post_build_script: |
   git_pkgbuild_commit()
-repo_depends:
-  - python-psutil
 update_on:
   - source: pypi
     pypi: pyhmmer

--- a/BioArchLinux/python-pyhmmer/lilac.yaml
+++ b/BioArchLinux/python-pyhmmer/lilac.yaml
@@ -1,0 +1,15 @@
+maintainers:
+  - github: althonos
+    email: althonosdev@gmail.com
+build_prefix: extra-x86_64
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+  run_cmd(['updpkgsums'])
+post_build_script: |
+  git_pkgbuild_commit()
+repo_depends:
+  - python-psutil
+update_on:
+  - source: pypi
+    pypi: pyhmmer
+  - alias: python


### PR DESCRIPTION
## Involved packages

 - `python-pyhmmer`

## Involved issue

N/A

## Details

- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [x] Provide New Package
- [ ] Fix the Packages
  - [ ] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [x] Would like to continue to work with us

## Additional Note

This PR adds a package for `python-pyhmmer` using the PKGBUILD I wrote for the AUR.