### PR TITLE
tbtools: fix entry name

### DIFF
--- a/BioArchLinux/tbtools/PKGBUILD
+++ b/BioArchLinux/tbtools/PKGBUILD
@@ -32,7 +32,7 @@ prepare() {
     # generate /usr/bin file
     printf '#!/usr/bin/sh\nexec java -jar /usr/share/tbtools/tbtools*.jar "$@"\n'>${srcdir}/${pkgname}
     # generate desk entry
-    gendesk -f -n --pkgname "${pkgname}" --pkgdesc "${pkgdesc}" --exec="${pkgname}" --name="Tool Box for biologistists" --categories="Science"
+    gendesk -f -n --pkgname "${pkgname}" --pkgdesc "${pkgdesc}" --exec="${pkgname}" --name="${pkgname}" --categories="Science"
 }
 
 package() {


### PR DESCRIPTION
new entry name "tbtools" may be better, especially works well in kde/gnome's search bar

## Involved packages

 - Packages_Name

## Involved issue

Close #

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [x] Fix the Packages
  - [x] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
