### PR TITLE
tbtools: update jre(>=11)

### DIFF
--- a/BioArchLinux/tbtools/PKGBUILD
+++ b/BioArchLinux/tbtools/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc='GUI/CommandLine Tool Box for biologistists to utilize NGS data. \
 arch=('x86_64')
 url='https://github.com/CJ-Chen/TBtools-II'
 license=('unknown')
-depends=('java-runtime'
+depends=('java-runtime>=11'
          'bash')
 makedepends=('unzip'
              'gendesk')


### PR DESCRIPTION
I tried jre(8,11,17,21,22) only jre8 can't run.
So update to jre>=11

## Involved packages

 - tbtools

## Involved issue

Close #

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [x] Fix the Packages
  - [x] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
