### PR TITLE
imagej2: add aur support

### DIFF
--- a/BioArchLinux/imagej2/lilac.yaml
+++ b/BioArchLinux/imagej2/lilac.yaml
@@ -8,6 +8,7 @@ pre_build_script: |
 
 post_build_script: |
   git_pkgbuild_commit()
+  update_aur_repo()
 
 update_on:
   - source: github


### PR DESCRIPTION
AUR's imagej2 was adopted by kiri

## Involved packages

 - imagej2

## Involved issue

add support for AUR

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [ ] Fix the Packages
  - [ ] PKGBUILD
  - [x] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
