### PR TITLE
jasp-desktop: add new modules for JASP

### DIFF
--- a/BioArchLinux/jasp-desktop/PKGBUILD
+++ b/BioArchLinux/jasp-desktop/PKGBUILD
@@ -73,6 +73,8 @@ depends=('r'
     "r-jaspvisualmodeling"
     "r-jaspacceptancesampling"
     "r-jaspqualitycontrol"
+    "r-jaspbff"
+    "r-jaspbfpack"
 )
 provides=($_pkgname)
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/jasp-stats/jasp-desktop/archive/refs/tags/v${pkgver}.tar.gz"

--- a/BioArchLinux/jasp-desktop/lilac.yaml
+++ b/BioArchLinux/jasp-desktop/lilac.yaml
@@ -42,6 +42,8 @@ repo_depends:
   - "r-jaspvisualmodeling"
   - "r-jaspacceptancesampling"
   - "r-jaspqualitycontrol"
+  - "r-jaspbff"
+  - "r-jaspbfpack"
 pre_build: vcs_update
 post_build: git_pkgbuild_commit
 update_on:

--- a/BioArchLinux/r-bff/PKGBUILD
+++ b/BioArchLinux/r-bff/PKGBUILD
@@ -1,0 +1,37 @@
+_pkgname=bff
+_pkgver=4.3.0
+pkgname=r-${_pkgname,,}
+pkgver=4.3.0
+pkgrel=1
+pkgdesc='Bayes Factor Functions'
+arch=('any')
+url="https://www.github.com/rshudde/${_pkgname}"
+license=('LGPL')
+depends=(
+  r
+  r-grdevices
+  r-ggplot2
+  r-matrix
+  r-gsl
+  r-stats
+  r-rlang
+)
+optdepends=(
+  r-testthat
+  r-knitr
+  r-rmarkdown
+  r-bsda
+  r-vdiffr
+)
+source=("${_pkgname}_${_pkgver}.tar.gz::${url}/archive/refs/tags/v${_pkgver}.tar.gz")
+sha256sums=('030e140d592e3ad533e880b46d2e894e578de9c326a9b090dcb192c957e1116f')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}
+# vim:set ts=2 sw=2 et:

--- a/BioArchLinux/r-bff/lilac.py
+++ b/BioArchLinux/r-bff/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+def pre_build():
+    for line in edit_file('PKGBUILD'):
+        if line.startswith('_pkgver='):
+            line = f'_pkgver={_G.newver}'
+        print(line)
+    update_pkgver_and_pkgrel(_G.newver.replace(':', '.').replace('-', '.'))
+
+def post_build():
+    git_pkgbuild_commit()
+    update_aur_repo()

--- a/BioArchLinux/r-bff/lilac.yaml
+++ b/BioArchLinux/r-bff/lilac.yaml
@@ -1,0 +1,16 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: sukanka
+  email: su975853527@gmail.com
+repo_depends:
+- r-grdevices
+- r-ggplot2
+- r-matrix
+- r-gsl
+- r-stats
+- r-rlang
+update_on:
+- regex: bff_([\d._-]+).tar.gz
+  source: regex
+  url: https://www.github.com/rshudde/BFF
+- alias: r

--- a/BioArchLinux/r-jaspbff/PKGBUILD
+++ b/BioArchLinux/r-jaspbff/PKGBUILD
@@ -1,0 +1,31 @@
+#Maintainer: sukanka <su975853527 AT gmail.com>
+_pkgname=jaspBff
+_pkgver=0.19.2
+pkgname=r-${_pkgname,,}
+pkgver=0.19.2
+pkgrel=1
+pkgdesc="A Bayes factor function module for JASP"
+arch=('any')
+url="https://github.com/jasp-stats/${_pkgname}"
+license=('GPL3')
+depends=(r
+  r-bff
+  r-jaspbase
+  r-jaspgraphs
+)
+groups=(r-jasp r-jaspextra)
+source=("${_pkgname}_${_pkgver}.tar.gz::${url}/archive/refs/tags/v${_pkgver}.tar.gz")
+sha256sums=('9d4823b62f6866bf48397a5f99817dbe912a83db65bec61bd4287050b3dab0fc')
+
+
+build() {
+
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
+  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
+}

--- a/BioArchLinux/r-jaspbff/lilac.py
+++ b/BioArchLinux/r-jaspbff/lilac.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+def pre_build():
+    for line in edit_file('PKGBUILD'):
+        if line.startswith('_pkgver='):
+            line = f'_pkgver={_G.newver}'
+        print(line)
+    update_pkgver_and_pkgrel(_G.newver.replace(':', '.').replace('-', '.'))

--- a/BioArchLinux/r-jaspbff/lilac.yaml
+++ b/BioArchLinux/r-jaspbff/lilac.yaml
@@ -1,0 +1,18 @@
+maintainers:
+- github: sukanka
+  email: su975853527@gmail.com
+build_prefix: extra-x86_64
+repo_depends:
+- r-jaspbase
+- r-jaspgraphs
+- r-bff
+pre_build: vcs_update
+post_build_script: |
+  git_pkgbuild_commit()
+  update_aur_repo()
+update_on:
+- source: github
+  github: jasp-stats/jaspBFF
+  use_max_tag: true
+  prefix: "v"
+- alias: r

--- a/BioArchLinux/r-jaspbfpack/PKGBUILD
+++ b/BioArchLinux/r-jaspbfpack/PKGBUILD
@@ -1,0 +1,36 @@
+#Maintainer: sukanka <su975853527 AT gmail.com>
+_pkgname=jaspBfpack
+_pkgver=0.19.0
+pkgname=r-${_pkgname,,}
+pkgver=0.19.0
+pkgrel=1
+pkgdesc="BFpack Module for JASP"
+arch=('any')
+url="https://github.com/jasp-stats/${_pkgname}"
+license=('GPL')
+depends=(r
+  r-bfpack
+  r-bain
+  r-stats
+  r-ggplot2
+  r-stringr
+  r-jaspbase
+  r-jaspgraphs
+  r-coda
+)
+groups=(r-jasp r-jaspextra)
+source=("${_pkgname}_${_pkgver}.tar.gz::${url}/archive/refs/tags/v${_pkgver}.tar.gz")
+sha256sums=('90da835d9ae0e8b348386a74dbd67efd3699c27346e09cbdf4614d53bf69dfc5')
+
+
+build() {
+
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
+  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
+}

--- a/BioArchLinux/r-jaspbfpack/lilac.py
+++ b/BioArchLinux/r-jaspbfpack/lilac.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+def pre_build():
+    for line in edit_file('PKGBUILD'):
+        if line.startswith('_pkgver='):
+            line = f'_pkgver={_G.newver}'
+        print(line)
+    update_pkgver_and_pkgrel(_G.newver.replace(':', '.').replace('-', '.'))

--- a/BioArchLinux/r-jaspbfpack/lilac.yaml
+++ b/BioArchLinux/r-jaspbfpack/lilac.yaml
@@ -1,0 +1,23 @@
+maintainers:
+- github: sukanka
+  email: su975853527@gmail.com
+build_prefix: extra-x86_64
+repo_depends:
+- r-bfpack
+- r-bain
+- r-stats
+- r-ggplot2
+- r-stringr
+- r-jaspbase
+- r-jaspgraphs
+- r-coda
+pre_build: vcs_update
+post_build_script: |
+  git_pkgbuild_commit()
+  update_aur_repo()
+update_on:
+- source: github
+  github: jasp-stats/jaspBfpack
+  use_max_tag: true
+  prefix: "v"
+- alias: r


### PR DESCRIPTION
## Involved packages

 - jasp-desktop

## Involved issue

Close #

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [x] Provide New Package
- [ ] Fix the Packages
  - [ ] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [x] Would like to continue to work with us

## Additional Note

cc @sukanka I don't have an Arch environment so I didn't test on local. dont know why I also cannot open build logs in https://build.bioarchlinux.org/ , seems it was shutdown.
