### PR TITLE
jaspmachinelearning: fix pkg r depends

### DIFF
--- a/BioArchLinux/r-jaspmachinelearning/lilac.yaml
+++ b/BioArchLinux/r-jaspmachinelearning/lilac.yaml
@@ -30,6 +30,7 @@ repo_depends:
 - r-rtsne
 - r-signal
 - r-kknn
+- r-vgam
 pre_build: vcs_update
 post_build: git_pkgbuild_commit
 update_on:


### PR DESCRIPTION
## Involved packages

 - jaspmachinelearning

## Involved issue

Close #

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [ ] Fix the Packages
  - [ ] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
