### PR TITLE
 r-ggsurvfit: remove dependence of r-survival

### DIFF
--- a/BioArchLinux/r-ggsurvfit/PKGBUILD
+++ b/BioArchLinux/r-ggsurvfit/PKGBUILD
@@ -18,7 +18,6 @@ depends=(
   r-glue
   r-gtable
   r-patchwork
-  r-survival
   r-tidyr
 )
 optdepends=(

--- a/BioArchLinux/r-ggsurvfit/lilac.yaml
+++ b/BioArchLinux/r-ggsurvfit/lilac.yaml
@@ -10,7 +10,6 @@ repo_depends:
 - r-glue
 - r-gtable
 - r-patchwork
-- r-survival
 - r-tidyr
 update_on:
 - regex: ggsurvfit_([\d._-]+).tar.gz


### PR DESCRIPTION
## Involved packages

 - Packages_Name

## Involved issue

Close #

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [ ] Fix the Packages
  - [ ] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
