### PR TITLE
canu: restore patches to use dependencies from repo

### DIFF
--- a/BioArchLinux/canu/PKGBUILD
+++ b/BioArchLinux/canu/PKGBUILD
@@ -1,35 +1,49 @@
 # Maintainer: Chocobo1 <chocobo1 AT archlinux DOT net>
 # Previous maintainer: Roberto Rossini ("robymetallo") <roberto.rossini.9533@student.uu.se>
-
+# Contributor: Bipin Kumar <kbipinkumar@pm.me>
 pkgname=canu
 pkgver=2.3
-pkgrel=0
+pkgrel=1
 pkgdesc="A single molecule sequence assembler for large and small genomes. https://doi.org/10.1101/gr.215087.116"
 arch=('i686' 'x86_64')
-url="https://canu.readthedocs.io/"
-license=('LicenseRef-canu')
-depends=('gcc-libs' 'java-runtime' 'perl')
+url="https://canu.readthedocs.io/en/latest/"
+license=('GPL-2.0-only AND BSD-3-Clause AND LicenseRef-Public Domain')
+makedepends=('git')
+depends=('gcc-libs' 'glibc' 'perl' 'mhap' 'zlib' 'xz' 'curl' 'bzip2')
 optdepends=('gnuplot')
 options=('staticlibs')
-source=("$pkgname-$pkgver-src.tar.xz::https://github.com/marbl/canu/releases/download/v$pkgver/canu-$pkgver.tar.xz")
-sha256sums=('ecb071943cde722152deb861d4ab897090f00b227fd0b261592e1e3fdd3e3e1a')
+source=("${pkgname}.${pkgver}.tar.xz::https://github.com/marbl/canu/releases/download/v${pkgver}/canu-${pkgver}.tar.xz"
+        'use-arch-mhap-at-runtime.patch'
+        'external-mhap.patch'
+)
+provides=('meryl')
+sha256sums=('ecb071943cde722152deb861d4ab897090f00b227fd0b261592e1e3fdd3e3e1a'
+            '0c84b28d99a933d04f57726f691d0057b911131b37c008d36670c0c05e1ca2ff'
+            'dfcb991b8b57fa138f5ecabbc60bdf119de2a5f2484882424f5835e0928e8421')
 
+prepare() {
+  cp *.patch ${pkgname}-${pkgver}/
+  cd ${pkgname}-${pkgver}
+  # create separate file for public domain license to match SPDX license and namcap guidelines
+  sed -n '80,96p' README.licenses > license-PD
+  # use mhap provided by Bioarchlinux repo
+  patch -p1 < use-arch-mhap-at-runtime.patch
+  patch -p1 < external-mhap.patch
+}
 
 build() {
-  cd "$pkgname-$pkgver"
-
+  cd ${pkgname}-${pkgver}/src
   CFLAGS="$CFLAGS -ffat-lto-objects" \
   CXXFLAGS="$CXXFLAGS -ffat-lto-objects" \
-  make -C "src"
+  make
 }
 
 package() {
   cd "$pkgname-$pkgver"
-
+  export perl=$(perl -V:vendorarch | awk -F'/' '{print $4}')
   install -Dm755 "build/bin"/* -t "$pkgdir/usr/bin"
-  install -Dm644 "build/lib/site_perl/canu"/*.pm -t "$pkgdir/usr/lib/site_perl/canu"
-  install -Dm644 "build/share/java/classes"/*.jar -t "$pkgdir/usr/share/java/classes"
+  install -Dm644 "build/lib/perl5/site_perl/canu"/*.pm -t "$pkgdir"/usr/share/${perl}/vendor_perl/canu
   install -Dm644 "build/lib"/*.a -t "$pkgdir/usr/lib"
-
-  install -Dm644 "README.licenses" -t "$pkgdir/usr/share/licenses/canu"
+  install -Dm644 README.licenses  "$pkgdir"/usr/share/licenses/$pkgname/license
+  install -Dm644 license-PD  "$pkgdir"/usr/share/licenses/$pkgname/license-PD
 }

--- a/BioArchLinux/canu/external-mhap.patch
+++ b/BioArchLinux/canu/external-mhap.patch
@@ -1,0 +1,10 @@
+--- canu-2.3.orig/src/main.mk	2024-12-16 21:53:18.000000000 +0530
++++ canu-2.3/src/main.mk	2025-02-08 15:21:30.531526902 +0530
+@@ -267,7 +267,6 @@
+                pipelines/draw-tig.pl                    -> bin/draw-tig
+ 
+ FILES       += pipelines/canu.defaults                  -> bin/canu.defaults \
+-               mhap/mhap-2.1.3.jar                      -> share/java/classes/mhap-2.1.3.jar \
+                pipelines/canu/Consensus.pm              -> lib/perl5/site_perl/canu/Consensus.pm \
+                pipelines/canu/CorrectReads.pm           -> lib/perl5/site_perl/canu/CorrectReads.pm \
+                pipelines/canu/HaplotypeReads.pm         -> lib/perl5/site_perl/canu/HaplotypeReads.pm \

--- a/BioArchLinux/canu/lilac.yaml
+++ b/BioArchLinux/canu/lilac.yaml
@@ -13,6 +13,3 @@ update_on:
     github: marbl/canu
     use_latest_release: true
     prefix: 'v'
-  - source: manual
-    manual: 1
-    time_limit_hours: 3

--- a/BioArchLinux/canu/use-arch-mhap-at-runtime.patch
+++ b/BioArchLinux/canu/use-arch-mhap-at-runtime.patch
@@ -1,0 +1,22 @@
+Description: Use mhap jar from mhap package provided by Bioarchlinux repo
+=======================================================================================
+--- canu-2.3.orig/src/pipelines/canu/OverlapMhap.pm	2024-11-25 23:30:00.000000000 +0530
++++ canu-2.3/src/pipelines/canu/OverlapMhap.pm	2025-02-08 13:35:27.079558823 +0530
+@@ -344,7 +344,7 @@
+     print F "cd ./blocks\n";
+     print F "\n";
+     print F "\$je $javaOpt -XX:ParallelGCThreads=",  getGlobal("${tag}mhapThreads"), " -server -Xms", $javaMemory, "m -Xmx", $javaMemory, "m \\\n";
+-    print F "  -jar $cygA \$bin/../share/java/classes/mhap-" . getGlobal("${tag}MhapVersion") . ".jar $cygB \\\n";
++    print F "  -jar $cygA /usr/share/mhap/mhap.jar $cygB \\\n";
+     print F "  --repeat-weight 0.9 --repeat-idf-scale 10 -k $merSize \\\n";
+     print F "  --supress-noise 2 \\\n"  if (defined(getGlobal("${tag}MhapFilterUnique")) && getGlobal("${tag}MhapFilterUnique") == 1);
+     print F "  --no-tf \\\n"            if (defined(getGlobal("${tag}MhapNoTf")) && getGlobal("${tag}MhapNoTf") == 1);
+@@ -467,7 +467,7 @@
+ 
+     print F "  #  Start up the producer.\n";
+     print F "  \$je $javaOpt -XX:ParallelGCThreads=",  getGlobal("${tag}mhapThreads"), " -server -Xms", $javaMemory, "m -Xmx", $javaMemory, "m \\\n";
+-    print F "    -jar $cygA \$bin/../share/java/classes/mhap-" . getGlobal("${tag}MhapVersion") . ".jar $cygB \\\n";
++    print F "    -jar $cygA /usr/share/mhap/mhap.jar $cygB \\\n";
+     print F "    --repeat-weight 0.9 --repeat-idf-scale 10 -k $merSize \\\n";
+     print F "    --supress-noise 2 \\\n"  if (defined(getGlobal("${tag}MhapFilterUnique")) && getGlobal("${tag}MhapFilterUnique") == 1);
+     print F "    --no-tf \\\n"            if (defined(getGlobal("${tag}MhapNoTf")) && getGlobal("${tag}MhapNoTf") == 1);


### PR DESCRIPTION
## Involved packages

 - canu

## Involved issue

Close NA

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [x] Fix the Packages
  - [x] PKGBUILD
  - [x] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
1. undo changes made in commit [here](https://github.com/BioArchLinux/Packages/commit/e7c8b88b8a641b8475331c6925eed8da939008ef) and restores patches so that `canu` will use `mhap` provided by the repo
2. fixes licenses array