### PR TITLE
strobealign: adding version 0.16.0

### DIFF
--- a/BioArchLinux/strobealign/PKGBUILD
+++ b/BioArchLinux/strobealign/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Martin Larralde <martin.larralde@embl.de>
+
+pkgname=strobealign
+pkgver=0.16.0
+pkgrel=1
+pkgdesc="Aligns short reads using dynamic seed size with strobemers. https://doi.org/10.1186/s13059-022-02831-7"
+arch=('x86_64' 'aarch64' 'ppc64le')
+url="https://github.com/ksahlin/strobealign"
+license=('MIT')
+depends=('glibc' 'openmp' 'zlib')
+makedepends=('cmake' 'isa-l')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
+sha256sums=('3fd4c95991a149b7edcafc91949a827d74f65e031ea08a73a878bef4ed123afa')
+
+prepare() {
+  local cmake_options=(
+    -B build
+    -S "$pkgname-$pkgver"
+    -W no-dev
+    -D CMAKE_BUILD_TYPE=None
+    -D CMAKE_INSTALL_PREFIX=/usr
+  )
+  cmake "${cmake_options[@]}"
+}
+
+build() {
+  cmake --build build
+}
+
+check() {
+  cd "$pkgname-$pkgver"
+  "$srcdir"/build/test-strobealign
+}
+
+package() {
+  DESTDIR="$pkgdir" cmake --install build
+  install -Dm644 -t "$pkgdir/usr/share/licenses/$pkgname" "$pkgname-$pkgver"/LICENSE
+}

--- a/BioArchLinux/strobealign/PKGBUILD
+++ b/BioArchLinux/strobealign/PKGBUILD
@@ -7,8 +7,8 @@ pkgdesc="Aligns short reads using dynamic seed size with strobemers. https://doi
 arch=('x86_64' 'aarch64' 'ppc64le')
 url="https://github.com/ksahlin/strobealign"
 license=('MIT')
-depends=('glibc' 'openmp' 'zlib')
-makedepends=('cmake' 'isa-l')
+depends=('glibc' 'openmp' 'zlib' 'isa-l')
+makedepends=('cmake')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
 sha256sums=('3fd4c95991a149b7edcafc91949a827d74f65e031ea08a73a878bef4ed123afa')
 

--- a/BioArchLinux/strobealign/lilac.yaml
+++ b/BioArchLinux/strobealign/lilac.yaml
@@ -1,0 +1,14 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: althonos
+    email: althonosdev@gmail.com
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver)
+post_build_script: |
+  git_pkgbuild_commit()
+  update_aur_repo()
+update_on:
+  - source: github
+    github: ksahlin/strobealign
+    use_max_tag: true
+    prefix: 'v'


### PR DESCRIPTION
This PR adds [`strobealign`](https://github.com/ksahlin/strobealign), another read aligner with very high performance. 

It builds inside the bioarchlinux/bioarchlinux Docker image with the dependencies and `base-devel` installed.

## Involved packages

 - `strobealign`

## Involved issue

N/A

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [x] Provide New Package
- [ ] Fix the Packages
  - [ ] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [x] Would like to continue to work with us

## Additional Note
