### PR TITLE
alevin-fry,chopper,cramino: get cargo fetch more generically

### DIFF
--- a/BioArchLinux/alevin-fry/PKGBUILD
+++ b/BioArchLinux/alevin-fry/PKGBUILD
@@ -15,7 +15,7 @@ sha256sums=('415106d13a39812ed0e671393480840477ff1a6073dcc794ffb52fa583460906')
 prepare() {
     cd ${pkgname}-${pkgver}
     export RUSTUP_TOOLCHAIN=stable
-    cargo fetch  --target "$CARCH-unknown-linux-gnu"
+    cargo fetch  --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
 build() {

--- a/BioArchLinux/chopper/PKGBUILD
+++ b/BioArchLinux/chopper/PKGBUILD
@@ -15,7 +15,7 @@ b2sums=('ad90dbf3c43ac775d9b4cdcca03782c74227e95c9fc6df6702415e6497ce0a16ca650a3
 prepare() {
     cd ${pkgname}-${pkgver}
     export RUSTUP_TOOLCHAIN=stable
-    cargo fetch  --target "$CARCH-unknown-linux-gnu"
+    cargo fetch  --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
 build() {

--- a/BioArchLinux/cramino/PKGBUILD
+++ b/BioArchLinux/cramino/PKGBUILD
@@ -15,7 +15,7 @@ sha256sums=('70b577982955cc8a736f07fe92e4ddb0855676ff9b98e7380c78aac67a7309f8')
 prepare() {
     cd ${pkgname}-${pkgver}
     export RUSTUP_TOOLCHAIN=stable
-    cargo fetch  --target "$CARCH-unknown-linux-gnu"
+    cargo fetch  --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
 build() {


### PR DESCRIPTION
From https://wiki.archlinux.org/title/Rust_package_guidelines#Prepare

This allows other architectures to fetch sources with cargo without a patch.

See https://gitlab.archlinux.org/groups/archlinux/packaging/-/epics/1

## Involved packages

- alevin-fry
- chopper
- cramino

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [x] Fix the Packages
  - [x] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [x] Would like to continue to work with us
