### PR TITLE
snapgene-viewer: change to manually update

### DIFF
--- a/BioArchLinux/snapgene-viewer/lilac.yaml
+++ b/BioArchLinux/snapgene-viewer/lilac.yaml
@@ -11,6 +11,5 @@ post_build_script: |
   git_pkgbuild_commit()
 
 update_on:
-  - source: regex
-    url: "https://www.snapgene.com/updates"
-    regex: '\"version\"\:\"(.*?)\"'
+  - source: manual
+    manual: 7.2.1


### PR DESCRIPTION
## Involved packages

 - snapgene-viewer

## Involved issue
Current version 7.2.1is the last version for snapgene-viewer as an independent package.
https://www.snapgene.com/snapgene-viewer: "SnapGene and SnapGene Viewer have been combined into a single SnapGene application. 

The new snapgene in Viewer Mod will show an ad banner in the bottom when open it, and need to close manually every time. So i decided to keep the snapgene-viewer and lock in 7.2.1 version.
Close #

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [ ] Fix the Packages
  - [ ] PKGBUILD
  - [x] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
