### PR TITLE
python-yte: include python-uv-build in makedepends

### DIFF
--- a/BioArchLinux/python-yte/PKGBUILD
+++ b/BioArchLinux/python-yte/PKGBUILD
@@ -10,7 +10,7 @@ arch=(any)
 url="https://github.com/koesterlab/$_name"
 license=(MIT)
 depends=(python-dpath python-plac python-pyyaml)
-makedepends=(python-poetry-core python-build python-installer python-wheel)
+makedepends=(python-poetry-core python-build python-installer python-wheel python-uv-build)
 source=("https://files.pythonhosted.org/packages/source/${_name::1}/$_name/$_name-$pkgver.tar.gz")
 sha256sums=('6eefbdceae56e156ba9881ecb63f3c9217cfe5d5cc6f85fdb061c266a8eff112')
 


### PR DESCRIPTION
Since yte now builds using uv, it needs to be added to makedepends

## Involved packages

 - python-yte

## Involved issue

Since yte now builds using uv, it needs to be added to makedepends

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [x] Fix the Packages
  - [x] PKGBUILD
- [x] Would like to continue to work with us

## Additional Note
