### PR TITLE
blast+: use ncbi-toolkit source

### DIFF
--- a/BioArchLinux/blast+/LICENSE
+++ b/BioArchLinux/blast+/LICENSE
@@ -1,0 +1,116 @@
+CONTENTS
+
+  Public Domain Notice
+  Exceptions (for bundled 3rd-party code)
+  Copyright F.A.Q.
+
+
+
+==============================================================
+                          PUBLIC DOMAIN NOTICE
+             National Center for Biotechnology Information
+
+With the exception of certain third-party files summarized below, this
+software is a "United States Government Work" under the terms of the
+United States Copyright Act.  It was written as part of the authors'
+official duties as United States Government employees and thus cannot
+be copyrighted.  This software is freely available to the public for
+use. The National Library of Medicine and the U.S. Government have not
+placed any restriction on its use or reproduction.
+
+Although all reasonable efforts have been taken to ensure the accuracy
+and reliability of the software and data, the NLM and the U.S.
+Government do not and cannot warrant the performance or results that
+may be obtained by using this software or data. The NLM and the U.S.
+Government disclaim all warranties, express or implied, including
+warranties of performance, merchantability or fitness for any
+particular purpose.
+
+Please cite the authors in any work or product based on this material.
+
+
+
+==============================================================
+EXCEPTIONS (in all cases excluding NCBI-written makefiles):
+
+
+Location: configure
+Authors:  Free Software Foundation, Inc.
+License:  Unrestricted; at top of file
+
+Location: config.guess, config.sub
+Authors:  FSF
+License:  Unrestricted when distributed with the Toolkit;
+          standalone, GNU General Public License [gpl.txt]
+
+Location: {src,include}/dbapi/driver/ftds*/freetds
+Authors:  See src/dbapi/driver/ftds*/freetds/AUTHORS
+License:  GNU Library/Lesser General Public License
+          [src/dbapi/driver/ftds*/freetds/COPYING.LIB]
+
+Location: include/dbapi/driver/odbc/unix_odbc
+Authors:  Peter Harvey and Nick Gorham
+License:  GNU LGPL
+
+Location: {src,include}/gui/widgets/FLU
+Authors:  Jason Bryan
+License:  GNU LGPL
+
+Location: {src,include}/gui/widgets/Fl_Table
+Authors:  Greg Ercolano
+License:  GNU LGPL
+
+Location: include/util/bitset
+Author:   Anatoliy Kuznetsov
+License:  MIT [include/util/bitset/license.txt]
+
+Location: {src,include}/util/compress/bzip2
+Author:   Julian R Seward
+License:  BSDish [src/util/compress/bzip2/LICENSE]
+
+Location: {src,include}/util/compress/zlib
+Authors:  Jean-loup Gailly and Mark Adler
+License:  BSDish [include/util/compress/zlib/zlib.h]
+
+Location: {src,include}/util/regexp
+Author:   Philip Hazel
+License:  BSDish [src/util/regexp/doc/LICENCE]
+
+Location: {src,include}/misc/xmlwrapp
+Author:   Peter J Jones at al. [src/misc/xmlwrapp/AUTHORS]
+License:  BSDish [src/misc/xmlwrapp/LICENSE]
+
+
+
+==============================================================
+Copyright F.A.Q.
+
+
+--------------------------------------------------------------
+Q. Our product makes use of the NCBI source code, and we did changes
+   and additions to that version of the NCBI code to better fit it to
+   our needs. Can we copyright the code, and how?
+
+A. You can copyright only the *changes* or the *additions* you made to the
+   NCBI source code. You should identify unambiguously those sections of
+   the code that were modified, e.g. by commenting any changes you made
+   in the code you distribute. Therefore, your license has to make clear
+   to users that your product is a combination of code that is public domain
+   within the U.S. (but may be subject to copyright by the U.S. in foreign
+   countries) and code that has been created or modified by you.
+
+
+--------------------------------------------------------------
+Q. Can we (re)license all or part of the NCBI source code?
+
+A. No, you cannot license or relicense the source code written by NCBI
+   since you cannot claim any copyright in the software that was developed
+   at NCBI as a 'government work' and consequently is in the public domain
+   within the U.S.
+
+
+--------------------------------------------------------------
+Q. What if these copyright guidelines are not clear enough or are not
+   applicable to my particular case?
+
+A. Contact us. Send your questions to 'toolbox@ncbi.nlm.nih.gov'.

--- a/BioArchLinux/blast+/PKGBUILD
+++ b/BioArchLinux/blast+/PKGBUILD
@@ -2,56 +2,89 @@
 # Maintainer: Nathaniel Stickney <nstickney@gmail.com>
 # Contributor: Christian Krause ("wookietreiber") <kizkizzbangbang@googlemail.com>
 # shellcheck disable=SC2034,SC2148,SC2154
-
 pkgname=blast+
-pkgver=2.16.0
-pkgrel=1
-pkgdesc="BLAST tool suite from NCBI (blastn, blastp, blastx, psiblast, etc)"
+pkgver=29.2.0
+_pkgver=${pkgver//./_}
+pkgrel=0
+pkgdesc="BLAST tool suite (blastn, blastp, blastx, psiblast) built from NCBI C++ toolkit sources"
 arch=('i686' 'x86_64')
 url="http://blast.ncbi.nlm.nih.gov/"
-license=('custom')
-depends=('glibc'
-         'gcc-libs'
-         'libelf'
-         'zlib'
-	 'bzip2'
-	 'lzo'
-	 'zstd'
-	 'db'
-	 'pcre'
-	 'perl'
-	 'python'
-	 'lmdb'
-	 'libuv'
-	 'libnghttp2'
-	 'sqlite')
-makedepends=('cpio' 'make')
-# conflicts with proj on libproj.so
-conflicts=('blast' 'blast+-bin' 'ncbi-blast')
-provides=('blast')
+license=('NCBI-PD')
+depends=('python' 'pcre2' 'sqlite' 'lzo' 'libtiff' 'giflib' 'libxpm' 'glibc' 'gcc-libs' 'curl'
+         'mariadb-libs' 'libpng' 'gnutls' 'libxml2' 'libxslt' 'lmdb' 'gnutls' 'openssl' 'krb5' 'hdf5' 'bzip2' 'zlib' 'lzo' 'zstd' 'bash' 'libjpeg-turbo' 'e2fsprogs' 'perl' 'db')
+makedepends=('autoconf' 'cpio')
+conflicts=('blast' 'blast+-bin' 'ncbi-blast' 'ncbi-tools++')
+provides=('blast' 'igblast')
 replaces=('ncbi-blast')
-source=("https://ftp.ncbi.nlm.nih.gov/blast/executables/LATEST/ncbi-blast-$pkgver+-src.tar.gz")
-sha256sums=('17c93cf009721023e5aecf5753f9c6a255d157561638b91b3ad7276fd6950c2b')
-
-prepare() {
-    cd "$srcdir"/ncbi-blast-"$pkgver"+-src/c++ || exit
-    ./configure \
-        --prefix=/usr \
-        --with-dll \
-        --with-mt
-}
+source=(${pkgname}-${pkgver}.tar.gz::https://github.com/ncbi/ncbi-cxx-toolkit-public/archive/refs/tags/release/${pkgver}.tar.gz
+        LICENSE)
+sha256sums=('4bb2701b2cc8b4b29b5cde10088142d3c71c0ffd59e5f3402a1a6eec3d07db7e'
+            '78bbf3f310ff43f1b5f711e7221d51da1e6f055831bd6c6941e0650bf1261df2')
 
 build() {
-    cd "$srcdir"/ncbi-blast-"$pkgver"+-src/c++ || exit
-    make
+  # Adapted from debian packaging
+  # refer https://ncbi.github.io/cxx-toolkit/pages/ch_config.html#ch_config.Configuring_with_UNI for details about build FLAGS
+  cd "$srcdir/ncbi-cxx-toolkit-public-release-${pkgver}"
+  rm -f "$srcdir"/build/inc/ncbiconf_unix.h # in case of previous build
+  #---------Prebuild project_tree_builder binary separately--------------------------------
+  export CONFIGURE_COMMON_FLAGS="\
+                          --without-autodep \
+                          --without-makefile-auto-update \
+                          --with-flat-makefile \
+                          --without-caution \
+                          --without-lzo \
+                          --without-debug \
+                          --without-downloaded-vdb \
+                          --without-sse42"
+  export NATIVE=".native"
+  export NATIVE_BINDIR="${srcdir}/BUILD${NATIVE}/bin"
+
+  export PREBUILT_DATATOOL_EXE=${NATIVE_BINDIR}/datatool
+  export PREBUILT_PTB_EXE=${NATIVE_BINDIR}/project_tree_builder
+  #export PREBUILT_DATATOOL_EXE PREBUILT_PTB_EXE
+  PREBUILT_PTB_EXE=bootstrap \
+            ./configure ${CONFIGURE_COMMON_FLAGS} --without-app \
+             --with-build-root=${srcdir}/BUILD${NATIVE}  ||  \
+            (tail -v -n +0 config.log BUILD.native/status/config.log; exit 1)
+	make -C ${srcdir}/BUILD${NATIVE}/build -f Makefile.flat \
+	    datatool.exe
+
+  #-----------build only blast binaries and dependencies------------------------------------
+    export proj="algo/blast/ app/ objmgr/ objtools/align_format/ objtools/blast/"
+    ./configure --without-autodep \
+      --without-makefile-auto-update \
+      --with-flat-makefile\
+      --without-caution\
+      --without-debug \
+      --without-downloaded-vdb \
+      --prefix=/usr \
+      --libdir=/lib/blast+ \
+      --with-bin-release \
+      --with-dll \
+      --with-mt \
+      --with-lmdb=/usr/lib \
+      --with-hdf5=/usr/lib \
+      --with-libxslt=/usr/lib \
+      --with-z=/usr/lib \
+      --with-bz2=/usr/lib \
+      --with-lzo=/usr/lib \
+      --with-zstd=/usr/lib \
+      --with-pcre2=/usr/lib \
+      --with-gnutls=/usr/lib \
+      --with-openssl=/usr/lib \
+      --with-krb5=/usr/lib/ \
+      --with-bdb=/usr/lib/ \
+      --with-curl=/usr/lib/ \
+      --without-boost \
+      --with-64 \
+      --with-build-root=${srcdir}/build_blast
+
+    cd $srcdir/build_blast/build
+    make -f Makefile.flat all_projects="${proj}"
 }
 
 package() {
-    cd "$srcdir"/ncbi-blast-"$pkgver"+-src/c++ || exit
-    make prefix="$pkgdir"/usr install
-    chmod +x "$pkgdir"/usr/lib/*.so
-    install -d "$pkgdir"/usr/share/licenses/"$pkgname"
-    echo 'public domain' >"$pkgdir"/usr/share/licenses/"$pkgname"/LICENSE
-
-    rm $pkgdir/usr/lib/libproj.so
+  cd "${srcdir}/ncbi-cxx-toolkit-public-release-${pkgver}"
+  make prefix="${pkgdir}"/usr libdir="${pkgdir}"/usr/lib/blast+ install
+  install -Dm644 "${srcdir}"/LICENSE "${pkgdir}"/usr/share/licenses/${pkgname}/license
 }

--- a/BioArchLinux/blast+/lilac.yaml
+++ b/BioArchLinux/blast+/lilac.yaml
@@ -1,13 +1,14 @@
+build_prefix: extra-x86_64
 maintainers:
   - github: starsareintherose
     email: kuoi@bioarchlinux.org
-build_prefix: extra-x86_64
 pre_build_script: |
   update_pkgver_and_pkgrel(_G.newver)
 post_build_script: |
   git_pkgbuild_commit()
 update_on:
-  - source: regex
-    url: "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST"
-    regex: '(\d+.\d+.\d+)'
+  - source: github
+    github: ncbi/ncbi-cxx-toolkit-public
+    use_latest_release: true
+    prefix: "release/"
 time_limit_hours: 4


### PR DESCRIPTION
## Involved packages

 - blast+

## Involved issue

Close #

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [x] Fix the Packages
  - [x] PKGBUILD
  - [x] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note

this modified `PKGBUILD` `uses ncbi-c++-toolkit` as source to build blast binaries. the process is adapted from debian `ncbi-blast+` package and uses system libraries wherever possible to avoid any conflicts with them. as shown screenshot below `libproj.so` that used to conflict with arch package is not even present the blast+ package file now.

![Screenshot_20250704_135953](https://github.com/user-attachments/assets/9df6df4c-e22d-48aa-bb22-d83894307e3f)

