### PR TITLE
python-smart_open: add python-setuptools-scm to makedepends

### DIFF
--- a/BioArchLinux/python-smart_open/PKGBUILD
+++ b/BioArchLinux/python-smart_open/PKGBUILD
@@ -14,7 +14,7 @@ optdepends=("python-boto3: AWS support"
 	"python-requests: HTTP support"
 	"python-paramiko: SSH support"
 	"python-zstandard: zstd support")
-makedepends=('python-build' 'python-installer' 'python-wheel' 'python-setuptools')
+makedepends=('python-build' 'python-installer' 'python-wheel' 'python-setuptools' 'python-setuptools-scm')
 provides=("python-smart-open")
 conflicts=("python-smart-open")
 source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/RaRe-Technologies/${_pkgname}/archive/v${pkgver}.tar.gz")


### PR DESCRIPTION
makedepends requires setuptools-scm

## Involved packages

 - python-smart_open

## Involved issue

Build was failing because of makedepends missing setuptools-scm package

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [x] Fix the Packages
  - [x] PKGBUILD
- [x] Would like to continue to work with us
