### PR TITLE
staden-io_lib: split htscodecs as separate dependency

### DIFF
--- a/BioArchLinux/htscodecs/PKGBUILD
+++ b/BioArchLinux/htscodecs/PKGBUILD
@@ -1,0 +1,25 @@
+# Maintainer: Michael Schubert <mschu.dev at gmail> github.com/mschubert/PKGBUILDs
+pkgname=htscodecs
+pkgver=1.6.4
+pkgrel=1
+pkgdesc="Custom compression for sequencing formats, e.g. CRAM"
+arch=('x86_64')
+url=https://github.com/samtools/htscodecs
+license=('BSD-3-Clause')
+depends=('bzip2' 'zlib' 'glibc')
+source=($pkgname-$pkgver.tar.gz::$url/releases/download/v$pkgver/htscodecs-$pkgver.tar.gz)
+sha256sums=('8dad8bea5ddd9bbc90f434bfad046faa950fa7a337641952a73bdebe63932ae5')
+
+build() {
+  cd $pkgname-$pkgver
+  aclocal
+  autoreconf --install
+  ./configure --prefix=/usr
+  make CFLAGS=-g
+}
+
+package() {
+  cd $pkgname-$pkgver
+  make DESTDIR="$pkgdir" install
+  install -Dm644 LICENSE.md "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/BioArchLinux/htscodecs/lilac.yaml
+++ b/BioArchLinux/htscodecs/lilac.yaml
@@ -1,0 +1,9 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: kbipinkumar
+    email: kbipinkumar@pm.me
+update_on:
+  - source: github
+    github: samtools/htscodecs
+    use_latest_release: true
+    prefix: v

--- a/BioArchLinux/staden-io_lib/PKGBUILD
+++ b/BioArchLinux/staden-io_lib/PKGBUILD
@@ -8,25 +8,27 @@ pkgrel=1
 pkgdesc="DNA sequence assembly (Gap4) and editing and analysis tools (Spin)"
 arch=('i686' 'x86_64')
 url="https://github.com/jkbonfield/io_lib"
-license=('BSD')
-depends=('curl')
-conflicts=('htscodecs')
-provides=('htscodecs')
-source=($pkgname-$pkgver.tar.gz::$url/releases/download/io_lib-$_pkgver/io_lib-$pkgver.tar.gz)
-sha256sums=('4e6f08265bee63211bb20feb4dc03993e57b447b90dc84a4c272cf1aed954e4f')
+license=('BSD-3-Clause')
+depends=('curl' 'htscodecs' 'zlib' 'libdeflate' 'bzip2' 'xz' 'glibc' 'bash')
+source=($pkgname-$pkgver.tar.gz::$url/releases/download/io_lib-$_pkgver/io_lib-$pkgver.tar.gz
+    'useoscodecs.patch')
+sha256sums=('4e6f08265bee63211bb20feb4dc03993e57b447b90dc84a4c272cf1aed954e4f'
+            '94127b4019ed6b0c3c4ad16464b82abde7e52faa5b49915a216a76c37b0be786')
+
+prepare() {
+  cd "$srcdir/$_pkgname-$pkgver"
+  patch -p1 < ${srcdir}/useoscodecs.patch
+}
 
 build() {
-  cd "$srcdir/$_pkgname-$pkgver/htscodecs"
-  autoreconf --force --install -v
-  ./configure --prefix=/usr
-
   cd "$srcdir/$_pkgname-$pkgver"
   autoreconf --force --install -v
-  ./configure --prefix=/usr
+  ./configure --prefix=/usr --with-libdeflate=/usr/lib
   make CFLAGS=-g
 }
 
 package() {
   cd "$srcdir/$_pkgname-$pkgver"
   make DESTDIR="$pkgdir" install
+  install -Dm644 COPYRIGHT "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }

--- a/BioArchLinux/staden-io_lib/lilac.yaml
+++ b/BioArchLinux/staden-io_lib/lilac.yaml
@@ -2,7 +2,8 @@ build_prefix: extra-x86_64
 maintainers:
   - github: starsareintherose
     email: kuoi@bioarchlinux.org
+repo_depends:
+  - htscodecs
 update_on:
   - source: cmd
     cmd: curl -sS https://raw.githubusercontent.com/jkbonfield/io_lib/master/CHANGES | grep 'Version ' | head -n 1 | awk '{print $2}'
-

--- a/BioArchLinux/staden-io_lib/useoscodecs.patch
+++ b/BioArchLinux/staden-io_lib/useoscodecs.patch
@@ -1,0 +1,27 @@
+Description: Use the packaged htscodecs library
+Author: Steffen Moeller <moeller@debian.org>
+Forwarded: not-needed
+Last-Updated: 2020-05-20
+
+--- staden-io-lib.orig/Makefile.am
++++ staden-io-lib/Makefile.am
+@@ -32,7 +32,7 @@
+ AUTOMAKE_OPTIONS = foreign no-dependencies
+ ACLOCAL_AMFLAGS = -I m4
+ 
+-SUBDIRS = htscodecs io_lib progs tests
++SUBDIRS = io_lib progs tests
+ 
+ man_MANS = \
+ 	man/man1/srf_index_hash.1 \
+--- staden-io-lib.orig/io_lib/Makefile.am
++++ staden-io-lib/io_lib/Makefile.am
+@@ -136,6 +136,6 @@
+ 	cram_block_compression.h \
+ 	version.h
+ 
+-libstaden_read_la_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/htscodecs @LIBCURL_CPPFLAGS@
++libstaden_read_la_CPPFLAGS = -I${top_srcdir} -I/usr/include/htscodecs @LIBCURL_CPPFLAGS@
+ libstaden_read_la_LDFLAGS = -version-info @VERS_CURRENT@:@VERS_REVISION@:@VERS_AGE@ 
+-libstaden_read_la_LIBADD = @LIBZ@ @LIBCURL@ ${top_builddir}/htscodecs/htscodecs/libhtscodecs.la
++libstaden_read_la_LIBADD = @LIBZ@ @LIBCURL@ -lhtscodecs


### PR DESCRIPTION
## Involved packages

 - staden-io_lib
 - htscodecs

## Involved issue

Close #

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [x] Provide New Package
- [X] Fix the Packages
  - [x] PKGBUILD
  - [X] lilac.yaml
  - [X] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
this pull request adds `htscodecs` as separate new package and modifies `staden-io_lib` so that it can dynamically link to `htscodecs`, 

down the line these changes, once merged, will enable `salmon` to be built using OS provided dependencies as much as possible. 

