### PR TITLE
jasp-desktop: try to fix build. DO NOT MERGE

### DIFF
--- a/BioArchLinux/jasp-desktop/PKGBUILD
+++ b/BioArchLinux/jasp-desktop/PKGBUILD
@@ -161,6 +161,9 @@ package() {
         ${pkgdir}/usr/lib/jasp-desktop/bin/JASPEngine
     sed -i "s|^Exec.*|Exec=jasp %f|g" \
         ${pkgdir}/usr/share/applications/org.jaspstats.JASP.desktop
+    pushd ${pkgdir}/usr/share/applications/
+    mv org.jaspstats.JASP.desktop org.jasp-stats.JASP.desktop
+    popd
 
     _add_libs
     rm -rf ${pkgdir}/usr/lib/jasp-desktop/{renv-root,renv-cache,bin/org.jaspstats.JASP}

--- a/BioArchLinux/jasp-desktop/PKGBUILD
+++ b/BioArchLinux/jasp-desktop/PKGBUILD
@@ -55,10 +55,6 @@ sha256sums=('7c0e0fdd6a28ddd484ccd39069da6cb20e03547d2d8ec14b69df5f05cabfa0b2'
 _add_libs() {
     local JASP_LIBS lib
     JASP_LIBS=(
-        # base
-        "jaspBase"
-        "jaspGraphs"
-        "jaspTools"
         # common
         "jaspDescriptives"
         "jaspTTests"
@@ -124,7 +120,7 @@ prepare() {
     sed -i 's|set(R_CPP_INCLUDES_LIBRARY.*|set(R_CPP_INCLUDES_LIBRARY /usr/lib/R/library)|g' Tools/CMake/R.cmake R-Interface/CMakeLists.txt
 
     # Do NOT install modules here, they are listed in dependencies
-    # find Modules/ -name '*.in' -print0 | xargs -0 sed -i '1,$d;1a print("I am OK!")'
+    find Modules/ -name '*.in' -print0 | xargs -0 sed -i '1,$d;1a TRUE'
 }
 
 build() {

--- a/BioArchLinux/jasp-desktop/PKGBUILD
+++ b/BioArchLinux/jasp-desktop/PKGBUILD
@@ -1,11 +1,11 @@
 #Maintainer: sukanka <su975853527 AT gmail.com>
 
 _pkgname=jasp
-_pkgver=0.19.3
+_pkgver=0.95.1
 pkgname=jasp-desktop
-pkgver=0.19.3
-_ColumnEncoder_ver=0.19.3
-pkgrel=3
+pkgver=0.95.1
+_ColumnEncoder_ver=0.95.1
+pkgrel=1
 pkgdesc="A complete statistical package for both Bayesian and Frequentist statistical methods"
 arch=('x86_64' 'aarch64')
 url="https://github.com/jasp-stats/jasp-desktop"
@@ -23,6 +23,7 @@ makedepends=("cmake" 'boost' 'jsoncpp'
     'patchelf'
     'ninja'
     'libfreexl'
+    'vulkan-headers'
 )
 depends=('r'
     'qt6-5compat'
@@ -32,6 +33,7 @@ depends=('r'
     'qt6-base'
     'qt6-webengine'
     'qt6-shadertools'
+    librdata
 
     # jaspBase
     "r-jaspbase"
@@ -80,23 +82,22 @@ depends=('r'
 provides=($_pkgname)
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/jasp-stats/jasp-desktop/archive/refs/tags/v${pkgver}.tar.gz"
     'jasp.sh'
-    "jaspColumnEncoder-${pkgver}.tar.gz::https://github.com/jasp-stats/jaspColumnEncoder/archive/refs/tags/v${_ColumnEncoder_ver}.tar.gz"
-    "jaspBase-${pkgver}.tar.gz::https://github.com/jasp-stats/jaspBase/archive/refs/tags/v${pkgver}.tar.gz"
-    "jaspGraphs-${pkgver}.tar.gz::https://github.com/jasp-stats/jaspGraphs/archive/refs/tags/v${pkgver}.tar.gz"
-    "jaspModuleInstaller-${pkgver}.tar.gz::https://github.com/jasp-stats/jaspModuleInstaller/archive/refs/tags/v${pkgver}.tar.gz"
+    "jaspColumnEncoder-${pkgver}.tar.gz::https://github.com/jasp-stats/jaspColumnEncoder/archive/32c53153da95087feb109c0f5f69534ffa3f32b7.zip"
+    "jaspBase-${pkgver}.tar.gz::https://github.com/jasp-stats/jaspBase/archive/0f0f59e18f5524ea422cb3dc5ad76ace6f0518e4.zip"
+    # "jaspGraphs-${pkgver}.tar.gz::https://github.com/jasp-stats/jaspGraphs/archive/refs/tags/v${pkgver}.tar.gz"
+    "jaspModuleBundleManager-${pkgver}.tar.gz::https://github.com/jasp-stats/jaspModuleBundleManager/archive/466057fe2ca0602917be964ce032c4cb03a8619a.zip"
 )
-sha256sums=('9078459cc091ac722552058733ef64c5792092c5fe5615d968b515054bc7efe9'
+sha256sums=('7c0e0fdd6a28ddd484ccd39069da6cb20e03547d2d8ec14b69df5f05cabfa0b2'
             'e0714d980e7549b4c7dcbae50370e95b6ad2e7f0cf21a534ceb3a5a83ee583fd'
-            '340de4aa4218fe6216b3a260b75c8256f3b6f501aadcf2c32253aa0e9a2f3c73'
-            '327bc22a5d0ab1a12935bf00327c7075df266a51a1097e502c0b89bc395ba6da'
-            '8db633010ac5ab56d12397dc391f515e7ee4b0faea38ddadac849b5be1d4e241'
-            '4abacceb643e9dcea4f1353ce200292bc395e21766b0998f0898d4cc70cd1ec8')
+            '8afdd494d59bc6812fb4d957070d7a92eb21eceecc954636abb264a37e1bcf86'
+            '6a6ed34ed5f2514fff7e9568c045ccf530586ed37ce08e409729c52ba1336c47'
+            'c6e58ca68cc157b7ba56ed6ac83ad1340be5c9f2148c80fb9713562e2dbe6e3f')
 
 prepare() {
-    for d in jaspBase jaspGraphs jaspModuleInstaller; do
-        cp -ar ${d}-${pkgver}/* ${pkgname}-${pkgver}/Engine/${d}
+    for d in jaspBase  jaspModuleBundleManager; do
+        cp -ar ${d}-*/* ${pkgname}-${pkgver}/Engine/${d}
     done
-    cp -ar jaspColumnEncoder-${_ColumnEncoder_ver}/* ${pkgname}-${pkgver}/Common/jaspColumnEncoder
+    cp -ar jaspColumnEncoder-*/* ${pkgname}-${pkgver}/Common/jaspColumnEncoder
     cd $srcdir/${pkgname}-${pkgver}
 
     find Tools/CMake -name *.cmake -print0 | xargs -0 sed -i "s|/usr/local|/usr|g"
@@ -122,7 +123,7 @@ build() {
 
     )
     # export GITHUB_PAT="None"
-    install -d build ${srcdir}/usr/lib/R
+    install -d build/Modules/Tools/ ${srcdir}/usr/lib/R
     cmake -S ${pkgname}-${pkgver} -B build "${cmake_args[@]}"
     ninja -C build
 }

--- a/BioArchLinux/jasp-desktop/PKGBUILD
+++ b/BioArchLinux/jasp-desktop/PKGBUILD
@@ -34,50 +34,7 @@ depends=('r'
     'qt6-webengine'
     'qt6-shadertools'
     librdata
-
-    # jaspBase
-    "r-jaspbase"
-    "r-jaspgraphs"
-    "r-jasptools"
-
-    #jaspCommon
-    "r-jaspdescriptives"
-    "r-jaspttests"
-    "r-jaspanova"
-    "r-jaspmixedmodels"
-    "r-jaspregression"
-    "r-jaspfrequencies"
-    "r-jaspfactor"
-
-    #jaspExtra
-    "r-jaspaudit"
-    "r-jaspbain"
-    "r-jaspbsts"
-    "r-jaspcircular"
-    "r-jaspcochrane"
-    "r-jaspdistributions"
-    "r-jaspequivalencettests"
-    "r-jaspjags"
-    "r-jasplearnbayes"
-    "r-jasplearnstats"
-    "r-jaspmachinelearning"
-    "r-jaspmetaanalysis"
-    "r-jaspnetwork"
-    "r-jasppower"
-    "r-jaspprocess"
-    "r-jaspprophet"
-    "r-jasppredictiveanalytics"
-    "r-jaspreliability"
-    "r-jasprobustttests"
-    "r-jaspsem"
-    "r-jaspsummarystatistics"
-    "r-jaspsurvival"
-    "r-jasptimeseries"
-    "r-jaspvisualmodeling"
-    "r-jaspacceptancesampling"
-    "r-jaspqualitycontrol"
-    "r-jaspbff"
-    "r-jaspbfpack"
+    libfreexl
 )
 provides=($_pkgname)
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/jasp-stats/jasp-desktop/archive/refs/tags/v${pkgver}.tar.gz"
@@ -86,26 +43,88 @@ source=("${pkgname}-${pkgver}.tar.gz::https://github.com/jasp-stats/jasp-desktop
     "jaspBase-${pkgver}.tar.gz::https://github.com/jasp-stats/jaspBase/archive/0f0f59e18f5524ea422cb3dc5ad76ace6f0518e4.zip"
     # "jaspGraphs-${pkgver}.tar.gz::https://github.com/jasp-stats/jaspGraphs/archive/refs/tags/v${pkgver}.tar.gz"
     "jaspModuleBundleManager-${pkgver}.tar.gz::https://github.com/jasp-stats/jaspModuleBundleManager/archive/466057fe2ca0602917be964ce032c4cb03a8619a.zip"
+    "remove_binary_pkgs.patch::https://github.com/jasp-stats/jasp-desktop/commit/3ff41e292c.patch"
 )
 sha256sums=('7c0e0fdd6a28ddd484ccd39069da6cb20e03547d2d8ec14b69df5f05cabfa0b2'
-            'e0714d980e7549b4c7dcbae50370e95b6ad2e7f0cf21a534ceb3a5a83ee583fd'
-            '8afdd494d59bc6812fb4d957070d7a92eb21eceecc954636abb264a37e1bcf86'
-            '6a6ed34ed5f2514fff7e9568c045ccf530586ed37ce08e409729c52ba1336c47'
-            'c6e58ca68cc157b7ba56ed6ac83ad1340be5c9f2148c80fb9713562e2dbe6e3f')
+    'e0714d980e7549b4c7dcbae50370e95b6ad2e7f0cf21a534ceb3a5a83ee583fd'
+    '8afdd494d59bc6812fb4d957070d7a92eb21eceecc954636abb264a37e1bcf86'
+    '6a6ed34ed5f2514fff7e9568c045ccf530586ed37ce08e409729c52ba1336c47'
+    'c6e58ca68cc157b7ba56ed6ac83ad1340be5c9f2148c80fb9713562e2dbe6e3f'
+    'f5c145c33cdcb4c254f7e9f0eb7639e8cdf6887e56e2f7c15074973504469889')
 
+_add_libs() {
+    local JASP_LIBS lib
+    JASP_LIBS=(
+        # base
+        "jaspBase"
+        "jaspGraphs"
+        "jaspTools"
+        # common
+        "jaspDescriptives"
+        "jaspTTests"
+        "jaspAnova"
+        "jaspMixedModels"
+        "jaspRegression"
+        "jaspFrequencies"
+        "jaspFactor"
+        # extra
+        "jaspAcceptanceSampling"
+        "jaspAudit"
+        "jaspBain"
+        "jaspBFF"
+        "jaspBfpack"
+        "jaspBsts"
+        "jaspCircular"
+        "jaspCochrane"
+        "jaspDistributions"
+        "jaspEquivalenceTTests"
+        # "jaspEsci"
+        "jaspJags"
+        "jaspLearnBayes"
+        "jaspLearnStats"
+        "jaspMachineLearning"
+        "jaspMetaAnalysis"
+        "jaspNetwork"
+        "jaspPower"
+        "jaspPredictiveAnalytics"
+        "jaspProcess"
+        "jaspProphet"
+        "jaspQualityControl"
+        "jaspReliability"
+        "jaspRobustTTests"
+        "jaspSem"
+        "jaspSurvival"
+        "jaspSummaryStatistics"
+        "jaspTimeSeries"
+        "jaspVisualModeling"
+        # "jaspTestModule"
+    )
+    install -d ${pkgdir}/usr/lib/jasp-desktop/Modules/module_libs/
+    for lib in "${JASP_LIBS[@]}"; do
+        depends+=("r-${lib,,}")
+        ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/module_libs/${lib}
+    done
+}
+_apply_patch() {
+    pushd $srcdir/${pkgname}-${pkgver}
+    patch -p1 <$srcdir/remove_binary_pkgs.patch
+    popd
+
+}
 prepare() {
-    for d in jaspBase  jaspModuleBundleManager; do
+    for d in jaspBase jaspModuleBundleManager; do
         cp -ar ${d}-*/* ${pkgname}-${pkgver}/Engine/${d}
     done
     cp -ar jaspColumnEncoder-*/* ${pkgname}-${pkgver}/Common/jaspColumnEncoder
     cd $srcdir/${pkgname}-${pkgver}
+    _apply_patch
 
     find Tools/CMake -name *.cmake -print0 | xargs -0 sed -i "s|/usr/local|/usr|g"
     sed -i "s|lib='\${R_LIBRARY_PATH}'|lib='${srcdir}/usr/lib/R'|g" Tools/CMake/R.cmake
     sed -i 's|set(R_CPP_INCLUDES_LIBRARY.*|set(R_CPP_INCLUDES_LIBRARY /usr/lib/R/library)|g' Tools/CMake/R.cmake R-Interface/CMakeLists.txt
 
     # Do NOT install modules here, they are listed in dependencies
-    find Modules/ -name '*.in' -print0 | xargs -0 sed -i '1,$d;1a print("I am OK!")'
+    # find Modules/ -name '*.in' -print0 | xargs -0 sed -i '1,$d;1a print("I am OK!")'
 }
 
 build() {
@@ -147,5 +166,6 @@ package() {
     sed -i "s|^Exec.*|Exec=jasp %f|g" \
         ${pkgdir}/usr/share/applications/org.jaspstats.JASP.desktop
 
+    _add_libs
     rm -rf ${pkgdir}/usr/lib/jasp-desktop/{renv-root,renv-cache,bin/org.jaspstats.JASP}
 }

--- a/BioArchLinux/jasp-desktop/lilac.yaml
+++ b/BioArchLinux/jasp-desktop/lilac.yaml
@@ -5,6 +5,7 @@ build_prefix: extra-x86_64
 repo_makedepends:
   - "jags"
 repo_depends:
+  - "librdata-git"
   - "r-rinside"
   - "r-jaspbase"
   - "r-jaspgraphs"

--- a/BioArchLinux/librdata/PKGBUILD
+++ b/BioArchLinux/librdata/PKGBUILD
@@ -1,26 +1,26 @@
 # Maintainer: sukanka <su975853527 [AT] gmail.com>
 
-pkgname=librdata
+pkgname=librdata-git
+_pkgname=librdata
 pkgver=0.1.0.r125.33bd276
-_commit=33bd276ec
 pkgrel=1
 pkgdesc="Read and write R data frames from C"
 arch=("x86_64" "aarch64")
 url="https://github.com/WizardMac/librdata"
 license=("MIT")
 depends=('bzip2' 'zlib' 'glibc' 'xz')
+provides=($_pkgname)
 makedepends=(make autoconf git gettext)
-source=("git+${url}.git#commit=${_commit}"
-)
-sha512sums=('e167d81e9304b6609c881787539ff790a0943eed123b407bc43453e9da6923acc7c383c49a1fe4e64ea053ef97cf58d54e90431cab77a2791d95003a88757276')
+source=("git+${url}.git")
+sha512sums=('SKIP')
 
 
 pkgver() {
-    cd ${srcdir}/${pkgname}
+    cd ${srcdir}/${_pkgname}
     printf "0.1.0.r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
 }
 build() {
-    cd ${srcdir}/${pkgname}
+    cd ${srcdir}/${_pkgname}
     autoreconf -fvi -I /usr/share/gettext/m4
     ./configure --prefix=/usr
     make
@@ -28,7 +28,7 @@ build() {
 }
 
 package() {
-    cd ${srcdir}/${pkgname}
+    cd ${srcdir}/${_pkgname}
     make install DESTDIR="${pkgdir}"
-    install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+    install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${_pkgname}/LICENSE"
 }

--- a/BioArchLinux/librdata/PKGBUILD
+++ b/BioArchLinux/librdata/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: sukanka <su975853527 [AT] gmail.com>
+
+pkgname=librdata
+pkgver=0.1.0.r125.33bd276
+_commit=33bd276ec
+pkgrel=1
+pkgdesc="Read and write R data frames from C"
+arch=("x86_64" "aarch64")
+url="https://github.com/WizardMac/librdata"
+license=("MIT")
+depends=('bzip2' 'zlib' 'glibc' 'xz')
+makedepends=(make autoconf git gettext)
+source=("git+${url}.git#commit=${_commit}"
+)
+sha512sums=('e167d81e9304b6609c881787539ff790a0943eed123b407bc43453e9da6923acc7c383c49a1fe4e64ea053ef97cf58d54e90431cab77a2791d95003a88757276')
+
+
+pkgver() {
+    cd ${srcdir}/${pkgname}
+    printf "0.1.0.r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
+}
+build() {
+    cd ${srcdir}/${pkgname}
+    autoreconf -fvi -I /usr/share/gettext/m4
+    ./configure --prefix=/usr
+    make
+
+}
+
+package() {
+    cd ${srcdir}/${pkgname}
+    make install DESTDIR="${pkgdir}"
+    install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/BioArchLinux/librdata/lilac.yaml
+++ b/BioArchLinux/librdata/lilac.yaml
@@ -1,0 +1,10 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: sukanka
+    email: sukanka@askk.cc
+pre_build: vcs_update
+post_build_script: |
+  git_pkgbuild_commit()
+update_on:
+  - source: github
+    github: WizardMac/librdata

--- a/BioArchLinux/r-jaspacceptancesampling/PKGBUILD
+++ b/BioArchLinux/r-jaspacceptancesampling/PKGBUILD
@@ -34,6 +34,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspanova/PKGBUILD
+++ b/BioArchLinux/r-jaspanova/PKGBUILD
@@ -46,6 +46,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspaudit/PKGBUILD
+++ b/BioArchLinux/r-jaspaudit/PKGBUILD
@@ -31,6 +31,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspbain/PKGBUILD
+++ b/BioArchLinux/r-jaspbain/PKGBUILD
@@ -32,6 +32,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspbase/PKGBUILD
+++ b/BioArchLinux/r-jaspbase/PKGBUILD
@@ -57,6 +57,4 @@ package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
   # we may or may not need this link.
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspbff/PKGBUILD
+++ b/BioArchLinux/r-jaspbff/PKGBUILD
@@ -25,6 +25,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspbfpack/PKGBUILD
+++ b/BioArchLinux/r-jaspbfpack/PKGBUILD
@@ -30,6 +30,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspbsts/PKGBUILD
+++ b/BioArchLinux/r-jaspbsts/PKGBUILD
@@ -31,6 +31,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspcircular/PKGBUILD
+++ b/BioArchLinux/r-jaspcircular/PKGBUILD
@@ -27,6 +27,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspcochrane/PKGBUILD
+++ b/BioArchLinux/r-jaspcochrane/PKGBUILD
@@ -28,6 +28,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspdescriptives/PKGBUILD
+++ b/BioArchLinux/r-jaspdescriptives/PKGBUILD
@@ -35,6 +35,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspdistributions/PKGBUILD
+++ b/BioArchLinux/r-jaspdistributions/PKGBUILD
@@ -32,6 +32,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspequivalencettests/PKGBUILD
+++ b/BioArchLinux/r-jaspequivalencettests/PKGBUILD
@@ -30,6 +30,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspfactor/PKGBUILD
+++ b/BioArchLinux/r-jaspfactor/PKGBUILD
@@ -34,6 +34,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspfrequencies/PKGBUILD
+++ b/BioArchLinux/r-jaspfrequencies/PKGBUILD
@@ -35,6 +35,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspgraphs/PKGBUILD
+++ b/BioArchLinux/r-jaspgraphs/PKGBUILD
@@ -33,6 +33,4 @@ package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
   # we may or may not need this link.
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspjags/PKGBUILD
+++ b/BioArchLinux/r-jaspjags/PKGBUILD
@@ -33,6 +33,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jasplearnbayes/PKGBUILD
+++ b/BioArchLinux/r-jasplearnbayes/PKGBUILD
@@ -40,6 +40,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jasplearnstats/PKGBUILD
+++ b/BioArchLinux/r-jasplearnstats/PKGBUILD
@@ -34,6 +34,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspmachinelearning/PKGBUILD
+++ b/BioArchLinux/r-jaspmachinelearning/PKGBUILD
@@ -51,6 +51,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspmetaanalysis/PKGBUILD
+++ b/BioArchLinux/r-jaspmetaanalysis/PKGBUILD
@@ -48,6 +48,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspmixedmodels/PKGBUILD
+++ b/BioArchLinux/r-jaspmixedmodels/PKGBUILD
@@ -35,6 +35,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspnetwork/PKGBUILD
+++ b/BioArchLinux/r-jaspnetwork/PKGBUILD
@@ -40,6 +40,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jasppower/PKGBUILD
+++ b/BioArchLinux/r-jasppower/PKGBUILD
@@ -26,6 +26,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jasppredictiveanalytics/PKGBUILD
+++ b/BioArchLinux/r-jasppredictiveanalytics/PKGBUILD
@@ -37,6 +37,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspprocess/PKGBUILD
+++ b/BioArchLinux/r-jaspprocess/PKGBUILD
@@ -31,6 +31,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspprophet/PKGBUILD
+++ b/BioArchLinux/r-jaspprophet/PKGBUILD
@@ -29,6 +29,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspqualitycontrol/PKGBUILD
+++ b/BioArchLinux/r-jaspqualitycontrol/PKGBUILD
@@ -50,6 +50,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspregression/PKGBUILD
+++ b/BioArchLinux/r-jaspregression/PKGBUILD
@@ -44,6 +44,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspreliability/PKGBUILD
+++ b/BioArchLinux/r-jaspreliability/PKGBUILD
@@ -36,6 +36,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jasprobustttests/PKGBUILD
+++ b/BioArchLinux/r-jasprobustttests/PKGBUILD
@@ -27,6 +27,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspsem/PKGBUILD
+++ b/BioArchLinux/r-jaspsem/PKGBUILD
@@ -36,6 +36,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspsummarystatistics/PKGBUILD
+++ b/BioArchLinux/r-jaspsummarystatistics/PKGBUILD
@@ -34,6 +34,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspsurvival/PKGBUILD
+++ b/BioArchLinux/r-jaspsurvival/PKGBUILD
@@ -28,6 +28,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jasptimeseries/PKGBUILD
+++ b/BioArchLinux/r-jasptimeseries/PKGBUILD
@@ -27,6 +27,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jasptools/PKGBUILD
+++ b/BioArchLinux/r-jasptools/PKGBUILD
@@ -39,6 +39,4 @@ package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
   # we may or may not need this link.
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspttests/PKGBUILD
+++ b/BioArchLinux/r-jaspttests/PKGBUILD
@@ -31,6 +31,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }

--- a/BioArchLinux/r-jaspvisualmodeling/PKGBUILD
+++ b/BioArchLinux/r-jaspvisualmodeling/PKGBUILD
@@ -27,6 +27,4 @@ build() {
 package() {
   install -dm0755 "${pkgdir}/usr/lib/R/library"
   cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
-  mkdir -p  ${pkgdir}/usr/lib/jasp-desktop/Modules
-  ln -s /usr/lib/R/library ${pkgdir}/usr/lib/jasp-desktop/Modules/${_pkgname}
 }


### PR DESCRIPTION
Currently package phase fails

## Involved packages

 - jasp-desktop

## Involved issue

Close #291 

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested on the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [ ] Fix the Packages
  - [ ] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note


The PKGBUILD fails at the package phase.

```
CMake Error at cmake_install.cmake:157 (file):
  file INSTALL cannot find
  "/build/jasp-desktop/src/build/Modules/binary_pkgs": No such file or
  directory.


FAILED: CMakeFiles/install.util 
cd /build/jasp-desktop/src/build && /usr/bin/cmake -P cmake_install.cmake
ninja: build stopped: subcommand failed.
```