### PR TITLE
infernal: trigger rebuild to link to latest GSL version

### DIFF
--- a/BioArchLinux/infernal/PKGBUILD
+++ b/BioArchLinux/infernal/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=infernal
 pkgver=1.1.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Tool for searching DNA sequence databases for RNA structure and sequence similarities"
 arch=('x86_64')
 url="http://eddylab.org/infernal/"


### PR DESCRIPTION
## Involved packages

 - `infernal`

## Involved issue

The current version of Infernal in ArchLinux links to GSL 2.7 (`libgsl.so.27`). The current GSL version on ArchLniux is 2.8. Some Infernal binaries cannot be executed because of missing `libgsl.so.27`:
```bash
$ cmbuild
cmbuild: error while loading shared libraries: libgsl.so.27: cannot open shared object file: No such file or directory
```
Simply rebuilding the package to link to GSL 2.8 fixes the issue.

## Details

- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [x] Fix the Packages
  - [ ] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
