### PR TITLE
r-ankir: add Anki database analysis and management R package

### DIFF
--- a/BioArchLinux/r-ankir/.gitignore
+++ b/BioArchLinux/r-ankir/.gitignore
@@ -1,5 +1,0 @@
-src/
-pkg/
-*.tar.gz
-*.tar.zst
-*.pkg.tar.*

--- a/BioArchLinux/r-ankir/PKGBUILD
+++ b/BioArchLinux/r-ankir/PKGBUILD
@@ -9,7 +9,6 @@ arch=(any)
 url="https://cran.r-project.org/package=$_pkgname"
 license=('GPL-3.0-or-later')
 depends=(
-  r
   r-rlang
   r-jsonlite
   r-dbi

--- a/BioArchLinux/r-ankir/lilac.py
+++ b/BioArchLinux/r-ankir/lilac.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+from lilaclib import *
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+def pre_build():
+    r_pre_build(_G)
+def post_build():
+    git_pkgbuild_commit()
+    update_aur_repo()

--- a/BioArchLinux/r-ankir/lilac.yaml
+++ b/BioArchLinux/r-ankir/lilac.yaml
@@ -1,6 +1,14 @@
 build_prefix: extra-x86_64
 maintainers:
 - github: chrislongros
+  email: chris.longros@gmail.com
+repo_depends:
+- r-rlang
+- r-jsonlite
+- r-dbi
+- r-rsqlite
+- r-tibble
+- r-scales
 update_on:
 - source: rpkgs
   pkgname: ankiR


### PR DESCRIPTION
I am the upstream author and CRAN maintainer of ankiR (https://cran.r-project.org/package=ankiR) and the AUR maintainer of r-ankir (https://aur.archlinux.org/packages/r-ankir).

ankiR provides comprehensive Anki database analysis with 137 exported functions covering FSRS algorithm analysis, retention modeling, deck statistics, forgetting curves, and export to multiple formats. It is used in medical education and spaced repetition research workflows.

I am interested in joining BioArchLinux as a contributor and would also be happy to maintain r-rlang and r-fansi (currently orphaned on AUR, broken due to CRAN Archive URL changes) within the repository.