### PR TITLE
python-pulp: python pulp

### DIFF
--- a/BioArchLinux/python-pulp/PKGBUILD
+++ b/BioArchLinux/python-pulp/PKGBUILD
@@ -10,7 +10,7 @@ arch=("any")
 license=("MIT")
 url="https://github.com/coin-or/pulp"
 depends=('python')
-makedepends=('python-build' 'python-installer' 'python-wheel' 'python-setuptools' 'python-maturin')
+makedepends=('python-build' 'python-installer' 'python-wheel' 'python-setuptools')
 source=($_name-$pkgver.tar.gz::$url/archive/refs/tags/$pkgver.tar.gz)
 sha256sums=('be723ce86afd0eb4c830080f83aa4e924f6a50d6f755877626a01daa9fff1c26')
 

--- a/BioArchLinux/python-pulp/PKGBUILD
+++ b/BioArchLinux/python-pulp/PKGBUILD
@@ -10,7 +10,7 @@ arch=("any")
 license=("MIT")
 url="https://github.com/coin-or/pulp"
 depends=('python')
-makedepends=('python-build' 'python-installer' 'python-wheel' 'python-setuptools')
+makedepends=('python-build' 'python-installer' 'python-wheel' 'python-setuptools' 'python-maturin')
 source=($_name-$pkgver.tar.gz::$url/archive/refs/tags/$pkgver.tar.gz)
 sha256sums=('be723ce86afd0eb4c830080f83aa4e924f6a50d6f755877626a01daa9fff1c26')
 

--- a/BioArchLinux/python-pulp/lilac.yaml
+++ b/BioArchLinux/python-pulp/lilac.yaml
@@ -9,7 +9,7 @@ post_build: git_pkgbuild_commit
 update_on:
 - source: github
   github: coin-or/pulp
-  use_max_tag: true
+  use_max_release: true
   prefix: v
 - source: manual
   manual: 1


### PR DESCRIPTION
## Involved packages

 - python-pulp

## Involved issue

Unnecessarily building alpha releases because of lilac.yaml config options. Changed it to `use_max_release` instead of `use_max_tag`

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [ ] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [ ] Provide New Package
- [ ] Fix the Packages
  - [ ] PKGBUILD
  - [ ] lilac.yaml
  - [ ] lilac.py
- [ ] Would like to continue to work with us

## Additional Note
