### PR TITLE
r-meta + r-metabook: init

### DIFF
--- a/BioArchLinux/r-meta/PKGBUILD
+++ b/BioArchLinux/r-meta/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Christos Longros <chris.longros@gmail.com>
+_pkgname=meta
+_pkgver=8.3-0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="General Package for Meta-Analysis"
+arch=(any)
+url="https://cran.r-project.org/package=$_pkgname"
+license=('GPL-2.0-or-later')
+depends=(
+  r-compquadform
+  r-dplyr
+  r-ggplot2
+  r-lme4
+  r-magrittr
+  r-metabook
+  r-metadat
+  r-metafor
+  r-purrr
+  r-readr
+  r-rlang
+  r-scales
+  r-stringr
+  r-tibble
+  r-xml2
+)
+optdepends=(
+  r-biasedurn
+  r-brglm2
+  r-estmeansd
+  r-gemtc
+  r-ggpubr
+  r-gridextra
+  r-knitr
+  r-netmeta
+  r-pimeta
+  r-rmarkdown
+  r-robvis
+  r-writexl
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('44bbe9108ed231e5ca36b627b16d9751')
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+}

--- a/BioArchLinux/r-meta/lilac.py
+++ b/BioArchLinux/r-meta/lilac.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+from lilaclib import *
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+def pre_build():
+    r_pre_build(_G)
+def post_build():
+    git_pkgbuild_commit()
+    update_aur_repo()

--- a/BioArchLinux/r-meta/lilac.yaml
+++ b/BioArchLinux/r-meta/lilac.yaml
@@ -1,0 +1,26 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: chrislongros
+  email: chris.longros@gmail.com
+repo_depends:
+- r-compquadform
+- r-dplyr
+- r-ggplot2
+- r-lme4
+- r-magrittr
+- r-metabook
+- r-metadat
+- r-metafor
+- r-purrr
+- r-readr
+- r-rlang
+- r-scales
+- r-stringr
+- r-tibble
+- r-xml2
+update_on:
+- source: rpkgs
+  pkgname: meta
+  repo: cran
+  md5: true
+- alias: r

--- a/BioArchLinux/r-metabook/PKGBUILD
+++ b/BioArchLinux/r-metabook/PKGBUILD
@@ -1,0 +1,23 @@
+# Maintainer: Christos Longros <chris.longros@gmail.com>
+_pkgname=metabook
+_pkgver=0.2-0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Data Sets and Code for 'Meta-Analysis with R'"
+arch=(any)
+url="https://cran.r-project.org/package=$_pkgname"
+license=('GPL-2.0-or-later')
+depends=(
+  r
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('e973a5a526a578dbeafc22f3e1acae59')
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+}

--- a/BioArchLinux/r-metabook/lilac.py
+++ b/BioArchLinux/r-metabook/lilac.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+from lilaclib import *
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+def pre_build():
+    r_pre_build(_G)
+def post_build():
+    git_pkgbuild_commit()
+    update_aur_repo()

--- a/BioArchLinux/r-metabook/lilac.yaml
+++ b/BioArchLinux/r-metabook/lilac.yaml
@@ -1,0 +1,10 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: chrislongros
+  email: chris.longros@gmail.com
+update_on:
+- source: rpkgs
+  pkgname: metabook
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
## Summary
- `r-meta` 8.3-0 — general package for meta-analysis (Schwarzer et al.)
- `r-metabook` 0.2-0 — prerequisite; data sets and code supporting *Meta-Analysis with R* (2nd ed.)

Both are pure R (no compilation). Verified locally with `aur build -c` on x86_64.

## Testing
- [x] `aur build -c r-metabook` clean
- [x] `aur build -c r-meta` clean
- [ ] `lilac` auto-update hook exercised on next CRAN release