### PR TITLE
r-metabook: fix pkgdesc quoting

### DIFF
--- a/BioArchLinux/r-metabook/PKGBUILD
+++ b/BioArchLinux/r-metabook/PKGBUILD
@@ -4,7 +4,7 @@ _pkgver=0.2-0
 pkgname=r-${_pkgname,,}
 pkgver=${_pkgver//-/.}
 pkgrel=1
-pkgdesc="Data Sets and Code for "Meta-Analysis with R""
+pkgdesc='Data Sets and Code for "Meta-Analysis with R"'
 arch=(any)
 url="https://cran.r-project.org/package=$_pkgname"
 license=('GPL-2.0-or-later')


### PR DESCRIPTION
Outer double quotes close on inner ones, breaking `source PKGBUILD`. Switch to single-quoted outer.