### PR TITLE
r-brms: add Bayesian Regression Models using 'Stan'

### DIFF
--- a/BioArchLinux/r-brms/PKGBUILD
+++ b/BioArchLinux/r-brms/PKGBUILD
@@ -1,0 +1,72 @@
+# Maintainer: Christos Longros <chris.longros@gmail.com>
+_pkgname=brms
+_pkgver=2.23.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Bayesian Regression Models using 'Stan'"
+arch=(any)
+url="https://cran.r-project.org/package=$_pkgname"
+license=('GPL-2.0-only')
+depends=(
+  r
+  r-abind
+  r-backports
+  r-bayesplot
+  r-bridgesampling
+  r-coda
+  r-future
+  r-future.apply
+  r-ggplot2
+  r-glue
+  r-loo
+  r-matrixstats
+  r-nleqslv
+  r-posterior
+  r-rcpp
+  r-rlang
+  r-rstan
+  r-rstantools
+)
+optdepends=(
+  r-emmeans
+  r-cmdstanr
+  r-projpred
+  r-priorsense
+  r-shinystan
+  r-splines2
+  r-rwiener
+  r-rtdists
+  r-extradistr
+  r-processx
+  r-mice
+  r-spdep
+  r-mnormt
+  r-lme4
+  r-mcmcglmm
+  r-ape
+  r-arm
+  r-statmod
+  r-digest
+  r-diffobj
+  r-betareg
+  r-r.rsp
+  r-gtable
+  r-shiny
+  r-knitr
+  r-rmarkdown
+  r-ragg
+  r-colorspace
+  r-mirai
+  r-future.mirai
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('e590eda39674cccda783081afb1c27b3')
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+}

--- a/BioArchLinux/r-brms/lilac.py
+++ b/BioArchLinux/r-brms/lilac.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+from lilaclib import *
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+def pre_build():
+    r_pre_build(_G)
+def post_build():
+    git_pkgbuild_commit()
+    update_aur_repo()

--- a/BioArchLinux/r-brms/lilac.yaml
+++ b/BioArchLinux/r-brms/lilac.yaml
@@ -1,0 +1,28 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: chrislongros
+  email: chris.longros@gmail.com
+repo_depends:
+- r-abind
+- r-backports
+- r-bayesplot
+- r-bridgesampling
+- r-coda
+- r-future
+- r-future.apply
+- r-ggplot2
+- r-glue
+- r-loo
+- r-matrixstats
+- r-nleqslv
+- r-posterior
+- r-rcpp
+- r-rlang
+- r-rstan
+- r-rstantools
+update_on:
+- source: rpkgs
+  pkgname: brms
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
Adds `r-brms` 2.23.0 (CRAN) — Bayesian regression models fitted via Stan.

Build-verified in a clean Arch chroot.