### PR TITLE
r-cardx: add Extra Analysis Results Data Utilities

### DIFF
--- a/BioArchLinux/r-cardx/PKGBUILD
+++ b/BioArchLinux/r-cardx/PKGBUILD
@@ -1,0 +1,50 @@
+# Maintainer: Christos Longros <chris.longros@gmail.com>
+
+_pkgname=cardx
+_pkgver=0.3.2
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Extra Analysis Results Data Utilities"
+arch=(any)
+url="https://cran.r-project.org/package=$_pkgname"
+license=('Apache-2.0')
+depends=(
+  r
+  r-cards
+  r-cli
+  r-dplyr
+  r-glue
+  r-lifecycle
+  r-rlang
+  r-tidyr
+)
+optdepends=(
+  r-aod
+  r-broom
+  r-broom.helpers
+  r-broom.mixed
+  r-car
+  r-effectsize
+  r-emmeans
+  r-geepack
+  r-ggsurvfit
+  r-lme4
+  r-parameters
+  r-survey
+  r-testthat
+  r-withr
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('51c13cffb6a98ccbde33b585ebed43ca')
+b2sums=('17f0c515a67c7440d6355e611939d475552a952be31f7097509e057ab9f7a787ecebe11eb833de3d00bf75be3d4abb89c446e33014af552f0e9a035c547a4ed5')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+}

--- a/BioArchLinux/r-cardx/PKGBUILD
+++ b/BioArchLinux/r-cardx/PKGBUILD
@@ -10,7 +10,6 @@ arch=(any)
 url="https://cran.r-project.org/package=$_pkgname"
 license=('Apache-2.0')
 depends=(
-  r
   r-cards
   r-cli
   r-dplyr

--- a/BioArchLinux/r-cardx/lilac.py
+++ b/BioArchLinux/r-cardx/lilac.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()
+    update_aur_repo()

--- a/BioArchLinux/r-cardx/lilac.yaml
+++ b/BioArchLinux/r-cardx/lilac.yaml
@@ -1,0 +1,18 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: chrislongros
+  email: chris.longros@gmail.com
+repo_depends:
+- r-cards
+- r-cli
+- r-dplyr
+- r-glue
+- r-lifecycle
+- r-rlang
+- r-tidyr
+update_on:
+- source: rpkgs
+  pkgname: cardx
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
Create extra Analysis Results Data (ARD) summary objects. The package supplements the simple ARD functions from the `cards` package, exporting functions to put statistical results in the ARD format — used to construct summary tables, visualisations, and written reports.