### PR TITLE
r-gtsummary: add Presentation-Ready Data Summary and Analytic Result Tables

### DIFF
--- a/BioArchLinux/r-gtsummary/PKGBUILD
+++ b/BioArchLinux/r-gtsummary/PKGBUILD
@@ -1,0 +1,64 @@
+# Maintainer: Christos Longros <chris.longros@gmail.com>
+
+_pkgname=gtsummary
+_pkgver=2.5.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Presentation-Ready Data Summary and Analytic Result Tables"
+arch=(any)
+url="https://cran.r-project.org/package=$_pkgname"
+license=('MIT')
+depends=(
+  r
+  r-cards
+  r-cardx
+  r-cli
+  r-dplyr
+  r-glue
+  r-gt
+  r-lifecycle
+  r-rlang
+  r-tidyr
+  r-vctrs
+)
+optdepends=(
+  r-aod
+  r-broom
+  r-broom.helpers
+  r-broom.mixed
+  r-car
+  r-effectsize
+  r-emmeans
+  r-flextable
+  r-geepack
+  r-ggstats
+  r-insight
+  r-kableextra
+  r-knitr
+  r-lme4
+  r-mice
+  r-officer
+  r-openxlsx
+  r-parameters
+  r-parsnip
+  r-rmarkdown
+  r-spelling
+  r-survey
+  r-testthat
+  r-withr
+  r-workflows
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('a64d44f70a93f71dec4c4115975a7048')
+b2sums=('b65b7409f4ffe6f2e1bf00d1987673312a4bbd02270bcdce412ed1d2a093bc1c2b4e9611c44cd58e39467c96427adb7d4f08eb1ec26e1018ac101ee135d81d04')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+}

--- a/BioArchLinux/r-gtsummary/PKGBUILD
+++ b/BioArchLinux/r-gtsummary/PKGBUILD
@@ -10,7 +10,6 @@ arch=(any)
 url="https://cran.r-project.org/package=$_pkgname"
 license=('MIT')
 depends=(
-  r
   r-cards
   r-cardx
   r-cli

--- a/BioArchLinux/r-gtsummary/lilac.py
+++ b/BioArchLinux/r-gtsummary/lilac.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()
+    update_aur_repo()

--- a/BioArchLinux/r-gtsummary/lilac.yaml
+++ b/BioArchLinux/r-gtsummary/lilac.yaml
@@ -1,0 +1,21 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: chrislongros
+  email: chris.longros@gmail.com
+repo_depends:
+- r-cards
+- r-cardx
+- r-cli
+- r-dplyr
+- r-glue
+- r-gt
+- r-lifecycle
+- r-rlang
+- r-tidyr
+- r-vctrs
+update_on:
+- source: rpkgs
+  pkgname: gtsummary
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
Creates presentation-ready tables summarising data sets and regression models. Supports summaries of arbitrary functions (mean, median, user-written), and auto-detects common regression models (logistic, Cox PH) to pre-fill reference rows and column headers.

Depends on #317 (r-cardx) — gtsummary's `Imports:` has `cardx (>= 0.3.1)`, so this PR cannot build until #317 lands. Please merge #317 first.