### PR TITLE
r-smd: add Compute Standardized Mean Differences

### DIFF
--- a/BioArchLinux/r-smd/PKGBUILD
+++ b/BioArchLinux/r-smd/PKGBUILD
@@ -9,9 +9,6 @@ pkgdesc="Compute Standardized Mean Differences"
 arch=(any)
 url="https://cran.r-project.org/package=$_pkgname"
 license=('MIT')
-depends=(
-  r
-)
 optdepends=(
   r-dplyr
   r-knitr

--- a/BioArchLinux/r-smd/PKGBUILD
+++ b/BioArchLinux/r-smd/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Christos Longros <chris.longros@gmail.com>
+
+_pkgname=smd
+_pkgver=0.8.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Compute Standardized Mean Differences"
+arch=(any)
+url="https://cran.r-project.org/package=$_pkgname"
+license=('MIT')
+depends=(
+  r
+)
+optdepends=(
+  r-dplyr
+  r-knitr
+  r-markdown
+  r-purrr
+  r-rmarkdown
+  r-stddiff
+  r-tableone
+  r-testthat
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('221f236ee8eab5b2f177fdd653d7319a')
+b2sums=('1a73d70a339dc52151027d4c7fee2662d992c9cfa7b39815345c7e1b0df9a04ab9b52231f88ca11aaade6b707caf710f929f61203631354357016b0aaf86cd75')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+  install -Dm644 "$_pkgname/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/BioArchLinux/r-smd/lilac.py
+++ b/BioArchLinux/r-smd/lilac.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()
+    update_aur_repo()

--- a/BioArchLinux/r-smd/lilac.yaml
+++ b/BioArchLinux/r-smd/lilac.yaml
@@ -1,0 +1,10 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: chrislongros
+  email: chris.longros@gmail.com
+update_on:
+- source: rpkgs
+  pkgname: smd
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
## Summary
- Adds r-smd (CRAN 0.8.0): standardized mean differences and confidence intervals.
- Pure R, arch=any, no compiled code; depends only on the recommended R bundle (MASS, methods).

## Build
Locally built clean with makepkg; package loads in R and computes the expected SMD on a small test vector.

## Why
Listed in the Suggests of r-cardx and r-gtsummary; required to satisfy `r_check_pkgbuild` for those packages.