### PR TITLE
r-gtsummary: add missing optdepends from upstream Suggests

### DIFF
--- a/BioArchLinux/r-gtsummary/PKGBUILD
+++ b/BioArchLinux/r-gtsummary/PKGBUILD
@@ -27,11 +27,13 @@ optdepends=(
   r-broom.helpers
   r-broom.mixed
   r-car
+  r-cmprsk
   r-effectsize
   r-emmeans
   r-flextable
   r-geepack
   r-ggstats
+  r-huxtable
   r-insight
   r-kableextra
   r-knitr
@@ -42,6 +44,7 @@ optdepends=(
   r-parameters
   r-parsnip
   r-rmarkdown
+  r-smd
   r-spelling
   r-survey
   r-testthat


### PR DESCRIPTION
## Summary
- Add r-cmprsk, r-huxtable and r-smd to optdepends.
- These are listed in the upstream gtsummary DESCRIPTION's Suggests but were missing from the merged PKGBUILD, so `r_check_pkgbuild` fails.

## Notes
- r-smd is being added in #319.
- r-cmprsk and r-huxtable are not yet packaged in BioArchLinux; the entries are accepted as advisory text by pacman and satisfy the metadata check.