### PR TITLE
r-marginaleffects: adding version 0.32.0

### DIFF
--- a/BioArchLinux/r-marginaleffects/PKGBUILD
+++ b/BioArchLinux/r-marginaleffects/PKGBUILD
@@ -1,0 +1,180 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=marginaleffects
+_pkgver=0.32.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc='Predictions, Comparisons, Slopes, Marginal Means, and Hypothesis Tests'
+arch=(any)
+url="https://marginaleffects.com/"
+license=('GPL-3.0-or-later')
+depends=(
+  r-backports
+  r-checkmate
+  r-data.table
+  r-formula
+  r-generics
+  r-insight
+  r-rlang
+)
+optdepends=(
+  r-aer
+  r-afex
+  r-altdoc
+  r-amelia
+  r-aod
+  r-arrow
+  r-bayestestr
+  r-bench
+  r-betareg
+  r-bh
+  r-bife
+  r-biglm
+  r-blme
+  r-brglm2
+  r-brms
+  r-brmsmargins
+  r-broom
+  r-car
+  r-cardata
+  r-causaldata
+  r-clarify
+  r-cjoint
+  r-clubsandwich
+  r-cobalt
+  r-collapse
+  r-conflicted
+  r-countrycode
+  r-covr
+  r-crch
+  r-dalex
+  r-dcchoice
+  r-dbarts
+  r-dfidx
+  r-dirichletreg
+  r-distributional
+  r-dplyr
+  r-emmeans
+  r-equivalence
+  r-estimatr
+  r-fixest
+  r-flexsurv
+  r-fmeffects
+  r-fontquiver
+  r-future
+  r-future.apply
+  r-fwb
+  r-gam
+  r-gamlss
+  r-gamlss.dist
+  r-geepack
+  r-ggdist
+  r-ggokabeito
+  r-ggplot2
+  r-ggrepel
+  r-glmmtmb
+  r-glmtoolbox
+  r-glmx
+  r-haven
+  r-here
+  r-itsadug
+  r-ivreg
+  r-kableextra
+  r-knitr
+  r-lme4
+  r-lmertest
+  r-logistf
+  r-magrittr
+  r-margins
+  r-matchit
+  r-mclogit
+  r-mcmcglmm
+  r-mhurdle
+  r-mice
+  r-miceadds
+  r-missranger
+  r-mlogit
+  r-mlr3verse
+  r-modelbased
+  r-modelsummary
+  r-multcomp
+  r-mvgam
+  r-mvtnorm
+  r-nanoparquet
+  r-numderiv
+  r-nycflights13
+  r-optmatch
+  r-ordbetareg
+  r-ordinal
+  r-parameters
+  r-parsnip
+  r-partykit
+  r-patchwork
+  r-pbapply
+  r-phylolm
+  r-pkgdown
+  r-plm
+  r-polspline
+  r-posterior
+  r-probably
+  r-pscl
+  r-purrr
+  r-quantreg
+  r-quantregforest
+  r-quarto
+  r-rchoice
+  r-rcmdcheck
+  r-rdatasets
+  r-remotes
+  r-rendo
+  r-reticulate
+  r-rmarkdown
+  r-robust
+  r-robustbase
+  r-robustlmm
+  r-rms
+  r-rsample
+  r-rstanarm
+  r-rstantools
+  r-rstpm2
+  r-rstudioapi
+  r-rsvg
+  r-sampleselection
+  r-sandwich
+  r-scam
+  r-spelling
+  r-speedglm
+  r-survey
+  r-svglite
+  r-systemfit
+  r-systemfonts
+  r-tibble
+  r-tictoc
+  r-tidymodels
+  r-tidyr
+  r-tidyverse
+  r-tinysnapshot
+  r-tinytable
+  r-tinytest
+  r-titanic
+  r-truncreg
+  r-tsmodel
+  r-withr
+  r-workflows
+  r-xgboost
+  r-yaml
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('b64b7d9f28dffabb6529da89088bfbd6')
+b2sums=('6af0c5251839cdd258677775173a432987622ec6c727d84f1a4ba9144d4f76f1efbea49aa27dca3b2ebe8600a185f21173abefda26fc1a8752f11c579cf4ca75')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}
+# vim:set ts=2 sw=2 et:

--- a/BioArchLinux/r-marginaleffects/lilac.py
+++ b/BioArchLinux/r-marginaleffects/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-marginaleffects/lilac.yaml
+++ b/BioArchLinux/r-marginaleffects/lilac.yaml
@@ -1,0 +1,18 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+repo_depends:
+- r-backports
+- r-checkmate
+- r-data.table
+- r-formula
+- r-generics
+- r-insight
+- r-rlang
+update_on:
+- source: rpkgs
+  pkgname: marginaleffects
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
Add the CRAN package `marginaleffects` 0.32.0.

`marginaleffects` computes predictions, comparisons, slopes, marginal means, and hypothesis tests for many R model classes.

Verification:
- `makepkg --verifysource`
- `makepkg -f`
