### PR TITLE
r-corrr: fix lilac rpkgs update

### DIFF
--- a/BioArchLinux/r-corrr/lilac.py
+++ b/BioArchLinux/r-corrr/lilac.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 from lilaclib import *
 
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
 def pre_build():
-    for line in edit_file('PKGBUILD'):
-        if line.startswith('_pkgver='):
-            line = f'_pkgver={_G.newver}'
-        print(line)
-    update_pkgver_and_pkgrel(_G.newver.replace(':', '.').replace('-', '.'))
+    r_pre_build(_G)
 
 def post_build():
     git_pkgbuild_commit()
+    update_aur_repo()


### PR DESCRIPTION
Fix the `r-corrr` Lilac update hook for `rpkgs` updates with `md5: true`.

The BioArch build error showed `_G.newver` arriving as `0.4.5#61e0c811a10eb6220e4eebdf9bcfbc39`. The old `lilac.py` wrote that full value into `_pkgver`, causing `updpkgsums` to request:

```text
https://cran.r-project.org/src/contrib/corrr_0.4.5#61e0c811a10eb6220e4eebdf9bcfbc39.tar.gz
```

This switches `r-corrr` to the shared `lilac_r_utils.r_pre_build()` helper used by other R packages, which splits the version and md5 correctly before running `updpkgsums`.

Verification:
- `python -m py_compile BioArchLinux/r-corrr/lilac.py`
- `makepkg --verifysource`
- `makepkg -f`
