### PR TITLE
r-modelsummary r-tinytable, r-tables: init pkgs

### DIFF
--- a/BioArchLinux/r-modelsummary/PKGBUILD
+++ b/BioArchLinux/r-modelsummary/PKGBUILD
@@ -1,0 +1,102 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=modelsummary
+_pkgver=2.6.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc='Summary Tables and Plots for Statistical Models and Data: Beautiful, Customizable, and Publication-Ready'
+arch=(any)
+url="https://modelsummary.com"
+license=('GPL-3.0-only')
+depends=(
+  r-checkmate
+  r-data.table
+  r-generics
+  r-glue
+  r-insight
+  r-parameters
+  r-performance
+  r-tables
+  r-tinytable
+)
+optdepends=(
+  r-aer
+  r-altdoc
+  r-amelia
+  r-betareg
+  r-bookdown
+  r-brms
+  r-broom
+  r-broom.mixed
+  r-car
+  r-clubsandwich
+  r-correlation
+  r-covr
+  r-did
+  r-digest
+  r-dt
+  r-estimatr
+  r-fixest
+  r-flextable
+  r-future
+  r-future.apply
+  r-gamlss
+  r-ggdist
+  r-ggplot2
+  r-gh
+  r-glmmtmb
+  r-gt
+  r-gtextras
+  r-haven
+  r-huxtable
+  r-irdisplay
+  r-ivreg
+  r-kableextra
+  r-knitr
+  r-labelled
+  r-lavaan
+  r-lfe
+  r-lme4
+  r-lmtest
+  r-magick
+  r-magrittr
+  r-marginaleffects
+  r-mice
+  r-officer
+  r-openxlsx
+  r-pandoc
+  r-pscl
+  r-psych
+  r-randomizr
+  r-rdatasets
+  r-remotes
+  r-rmarkdown
+  r-rstanarm
+  r-rsvg
+  r-sandwich
+  r-spelling
+  r-survey
+  r-tibble
+  r-tictoc
+  r-tidyselect
+  r-tidyverse
+  r-tinysnapshot
+  r-tinytest
+  r-tinytex
+  r-webshot2
+  r-wesanderson
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('7014ea9552c414d9539b8f733cfd2aa6')
+b2sums=('d592bb90d6456daab6655c42d3f8c9caf3e24a7f29d5ff30d2df0a2881950e2f33d4aa0ae44381c64f62e3c83787bc95022fdf2e3831a6a074fd964b67cdcd65')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}
+# vim:set ts=2 sw=2 et:

--- a/BioArchLinux/r-modelsummary/lilac.py
+++ b/BioArchLinux/r-modelsummary/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-modelsummary/lilac.yaml
+++ b/BioArchLinux/r-modelsummary/lilac.yaml
@@ -1,0 +1,20 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+repo_depends:
+- r-checkmate
+- r-data.table
+- r-generics
+- r-glue
+- r-insight
+- r-parameters
+- r-performance
+- r-tables
+- r-tinytable
+update_on:
+- source: rpkgs
+  pkgname: modelsummary
+  repo: cran
+  md5: true
+- alias: r

--- a/BioArchLinux/r-tables/PKGBUILD
+++ b/BioArchLinux/r-tables/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=tables
+_pkgver=0.9.33
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc='Formula-Driven Table Generation'
+arch=(any)
+url="https://dmurdoch.github.io/tables/"
+license=('GPL-2.0-only')
+depends=(
+  r-htmltools
+  r-knitr
+)
+optdepends=(
+  r-bookdown
+  r-formatters
+  r-hmisc
+  r-kableextra
+  r-magrittr
+  r-pkgdown
+  r-rmarkdown
+  r-tinytable
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('1205aece418c81b88a632eab3aeb2ec9')
+b2sums=('b09d041f9d355227a86c23f96f3b56139d50142748b4a5798acaa3fdfb6f6e3d9441b463687231ae3a3ab3cbfe6098fbbf827690b221ad172b47eac521efb331')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}
+# vim:set ts=2 sw=2 et:

--- a/BioArchLinux/r-tables/lilac.py
+++ b/BioArchLinux/r-tables/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-tables/lilac.yaml
+++ b/BioArchLinux/r-tables/lilac.yaml
@@ -1,0 +1,13 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+repo_depends:
+- r-htmltools
+- r-knitr
+update_on:
+- source: rpkgs
+  pkgname: tables
+  repo: cran
+  md5: true
+- alias: r

--- a/BioArchLinux/r-tinytable/PKGBUILD
+++ b/BioArchLinux/r-tinytable/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=tinytable
+_pkgver=0.16.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Simple and Configurable Tables in 'HTML', 'LaTeX', 'Markdown', 'Word', 'PNG', 'PDF', and 'Typst' Formats"
+arch=(any)
+url="https://vincentarelbundock.github.io/tinytable/"
+license=('GPL-3.0-or-later')
+depends=(
+  r
+)
+optdepends=(
+  r-base64enc
+  r-broom
+  r-data.table
+  r-estimatr
+  r-ggplot2
+  r-gh
+  r-glue
+  r-htmltools
+  r-litedown
+  r-magrittr
+  r-marginaleffects
+  r-modelsummary
+  r-pandoc
+  r-pkgdown
+  r-quarto
+  r-rdatasets
+  r-rmarkdown
+  r-rstudioapi
+  r-scales
+  r-stringi
+  r-tibble
+  r-tinysnapshot
+  r-tinytest
+  r-tinytex
+  r-webshot2
+  r-xfun
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('d6d2afee92702ee1cdd419783da755ce')
+b2sums=('a236d3647bcf2b2f4fb21d7fd8caeb6656015e971bb38af6dc686e8b7682cd1e62eb974cea2af598d8335e9b5dff31816a304b7f6250b7dd785a25d6e0869d25')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}
+# vim:set ts=2 sw=2 et:

--- a/BioArchLinux/r-tinytable/lilac.py
+++ b/BioArchLinux/r-tinytable/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-tinytable/lilac.yaml
+++ b/BioArchLinux/r-tinytable/lilac.yaml
@@ -1,0 +1,10 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+update_on:
+- source: rpkgs
+  pkgname: tinytable
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
Add the CRAN package `modelsummary` 2.6.0 and its missing runtime dependencies, `tinytable` and `tables`.

`modelsummary` creates customizable summary tables and plots for statistical models and data, with output formats including HTML, LaTeX, Word, Markdown, PDF, PowerPoint, Excel, RTF, JPG, and PNG.

Verification:
- `python -m py_compile BioArchLinux/r-tinytable/lilac.py BioArchLinux/r-tables/lilac.py BioArchLinux/r-modelsummary/lilac.py`
- `makepkg -f --verifysource` for `r-tinytable`, `r-tables`, and `r-modelsummary`
- `makepkg -f` for `r-tinytable` and `r-tables`
- `R_LIBS=/tmp/modelsummary-r-lib makepkg -f -d` for `r-modelsummary`, using a temporary R library with locally built `tinytable` and `tables`
