### PR TITLE
r-usmap r-usmapdata: init pkgs

### DIFF
--- a/BioArchLinux/r-usmap/PKGBUILD
+++ b/BioArchLinux/r-usmap/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=usmap
+_pkgver=1.0.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="US Maps Including Alaska and Hawaii"
+arch=(any)
+url="https://usmap.dev"
+license=('GPL-3.0-or-later')
+depends=(
+  r
+  r-rlang
+  r-usmapdata
+)
+optdepends=(
+  r-covr
+  r-ggplot2
+  r-ggrepel
+  r-knitr
+  r-proto
+  r-rmarkdown
+  r-scales
+  r-sf
+  r-spelling
+  r-testthat
+  r-vdiffr
+  r-withr
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('414bfe0840e2b9f36f8f4e4ef6851b8c')
+b2sums=('867c0c1f6a9ffac121bddc1c22c9a1b49c2f503daa26f13d4bcb47da33faa2cd5b466258b3a743b85de1297b11e563c11df5612fb894c6d2e628c61187952462')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}

--- a/BioArchLinux/r-usmap/PKGBUILD
+++ b/BioArchLinux/r-usmap/PKGBUILD
@@ -10,7 +10,6 @@ arch=(any)
 url="https://usmap.dev"
 license=('GPL-3.0-or-later')
 depends=(
-  r
   r-rlang
   r-usmapdata
 )

--- a/BioArchLinux/r-usmap/lilac.py
+++ b/BioArchLinux/r-usmap/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-usmap/lilac.yaml
+++ b/BioArchLinux/r-usmap/lilac.yaml
@@ -1,0 +1,13 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+repo_depends:
+- r-rlang
+- r-usmapdata
+update_on:
+- source: rpkgs
+  pkgname: usmap
+  repo: cran
+  md5: true
+- alias: r

--- a/BioArchLinux/r-usmapdata/PKGBUILD
+++ b/BioArchLinux/r-usmapdata/PKGBUILD
@@ -10,7 +10,6 @@ arch=(any)
 url="https://usmap.dev"
 license=('GPL-3.0-or-later')
 depends=(
-  r
   r-rlang
   r-sf
 )

--- a/BioArchLinux/r-usmapdata/PKGBUILD
+++ b/BioArchLinux/r-usmapdata/PKGBUILD
@@ -1,0 +1,35 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=usmapdata
+_pkgver=1.0.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Mapping Data for 'usmap' Package"
+arch=(any)
+url="https://usmap.dev"
+license=('GPL-3.0-or-later')
+depends=(
+  r
+  r-rlang
+  r-sf
+)
+optdepends=(
+  r-covr
+  r-dplyr
+  r-spelling
+  r-testthat
+  r-withr
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('548c9ca61ca6197148fce35c9c031320')
+b2sums=('0c00d9046aaa4296ee66f9e96cf3135b870b17b897e3f0bef383c0b475d43ebc75b892058d5cd136668ca845f613e0a851aecf24ab15b8aceff5a31cfca605c4')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}

--- a/BioArchLinux/r-usmapdata/lilac.py
+++ b/BioArchLinux/r-usmapdata/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-usmapdata/lilac.yaml
+++ b/BioArchLinux/r-usmapdata/lilac.yaml
@@ -1,0 +1,13 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+repo_depends:
+- r-rlang
+- r-sf
+update_on:
+- source: rpkgs
+  pkgname: usmapdata
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
Add CRAN packages `usmap` 1.0.0 and `usmapdata` 1.0.0.

`usmap` provides US map data and plotting helpers with Alaska and Hawaii repositioned for common US map layouts. `usmapdata` contains the map data used by `usmap`.

Verification:
- `python -m py_compile BioArchLinux/r-usmap/lilac.py BioArchLinux/r-usmapdata/lilac.py`
- `makepkg -f --verifysource` for `r-usmapdata`
- `makepkg -f` for `r-usmapdata`
- `makepkg -f --verifysource` for `r-usmap`
- `R_LIBS=/tmp/usmap-r-lib makepkg -f -d` for `r-usmap`, using a temporary R library with locally installed `usmapdata`
