### PR TITLE
r-leaflet.providers: add Default Configurations for Extra Map Tile Providers Used by 'leaflet'

### DIFF
--- a/BioArchLinux/r-leaflet.providers/PKGBUILD
+++ b/BioArchLinux/r-leaflet.providers/PKGBUILD
@@ -1,0 +1,28 @@
+# Maintainer: Christos Longros <chris.longros@gmail.com>
+_pkgname=leaflet.providers
+_pkgver=3.0.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Default Configurations for Extra Map Tile Providers Used by 'leaflet'"
+arch=(any)
+url="https://cran.r-project.org/package=$_pkgname"
+license=('BSD-2-Clause')
+depends=(
+  r-htmltools
+)
+optdepends=(
+  r-jsonlite
+  r-v8
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('1ad3d285a18259618b892a6fccf169bd')
+b2sums=('5801697aab5ccaa7909909b21df832d7f36a58ac094d2de5e3237bc64cc466aba10aa1f165c03805d7248f2012100e4beafff8c6264e2ff4be1e0fe15a0bbcbc')
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+}

--- a/BioArchLinux/r-leaflet.providers/lilac.py
+++ b/BioArchLinux/r-leaflet.providers/lilac.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+from lilaclib import *
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+def pre_build():
+    r_pre_build(_G)
+def post_build():
+    git_pkgbuild_commit()
+    update_aur_repo()

--- a/BioArchLinux/r-leaflet.providers/lilac.yaml
+++ b/BioArchLinux/r-leaflet.providers/lilac.yaml
@@ -1,0 +1,12 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: chrislongros
+  email: chris.longros@gmail.com
+repo_depends:
+- r-htmltools
+update_on:
+- source: rpkgs
+  pkgname: leaflet.providers
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
Add CRAN package `leaflet.providers` 3.0.0.

Contains third-party map tile provider information from 'Leaflet.js'
to be used with the 'leaflet' R package, with the ability to fetch
up-to-date provider info between package updates.

Verification:
- makepkg --verifysource
- makepkg -f