### PR TITLE
r-leaflet: add Create Interactive Web Maps with the JavaScript 'Leaflet' Library

### DIFF
--- a/BioArchLinux/r-leaflet/PKGBUILD
+++ b/BioArchLinux/r-leaflet/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Christos Longros <chris.longros@gmail.com>
+_pkgname=leaflet
+_pkgver=2.2.3
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Create Interactive Web Maps with the JavaScript 'Leaflet' Library"
+arch=(any)
+url="https://cran.r-project.org/package=$_pkgname"
+license=('MIT')
+depends=(
+  r-crosstalk
+  r-htmltools
+  r-htmlwidgets
+  r-jquerylib
+  r-leaflet.providers
+  r-magrittr
+  r-png
+  r-raster
+  r-rcolorbrewer
+  r-rlang
+  r-scales
+  r-sf
+  r-viridislite
+  r-xfun
+)
+optdepends=(
+  r-knitr
+  r-maps
+  r-purrr
+  r-r6
+  r-rjsonio
+  r-rmarkdown
+  r-s2
+  r-shiny
+  r-sp
+  r-terra
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('916c5eb105870df189cb04df996ac186')
+b2sums=('81bb0075a5199e231b9a034733f1dfab97b19dfa8ce1e629fc92948b310cd5f44f3bd535dc164cff70218071229ef11a2ae78f2ac4cab5fb7002ce060b164286')
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+}

--- a/BioArchLinux/r-leaflet/lilac.py
+++ b/BioArchLinux/r-leaflet/lilac.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+from lilaclib import *
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+def pre_build():
+    r_pre_build(_G)
+def post_build():
+    git_pkgbuild_commit()
+    update_aur_repo()

--- a/BioArchLinux/r-leaflet/lilac.yaml
+++ b/BioArchLinux/r-leaflet/lilac.yaml
@@ -1,0 +1,25 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: chrislongros
+  email: chris.longros@gmail.com
+repo_depends:
+- r-crosstalk
+- r-htmltools
+- r-htmlwidgets
+- r-jquerylib
+- r-leaflet.providers
+- r-magrittr
+- r-png
+- r-raster
+- r-rcolorbrewer
+- r-rlang
+- r-scales
+- r-sf
+- r-viridislite
+- r-xfun
+update_on:
+- source: rpkgs
+  pkgname: leaflet
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
Add CRAN package `leaflet` 2.2.3.

Create and customize interactive maps using the 'Leaflet' JavaScript
library and the 'htmlwidgets' package; usable from the R console,
'RStudio', Shiny apps, and R Markdown documents.

Depends on r-leaflet.providers (#327).

Verification:
- makepkg --verifysource
- makepkg -f