### PR TITLE
r-cmprsk: add Subdistribution Analysis of Competing Risks

### DIFF
--- a/BioArchLinux/r-cmprsk/PKGBUILD
+++ b/BioArchLinux/r-cmprsk/PKGBUILD
@@ -1,0 +1,27 @@
+# Maintainer: Christos Longros <chris.longros@gmail.com>
+_pkgname=cmprsk
+_pkgver=2.2-12
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Subdistribution Analysis of Competing Risks"
+arch=(any)
+url="https://cran.r-project.org/package=$_pkgname"
+license=('GPL-2.0-or-later')
+depends=(
+  r
+)
+makedepends=(
+  gcc-fortran
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('ae85888a4daf6417d48fc35cb306e909')
+b2sums=('e67727de09f735054c796ab1aebeff4781f43526b755478a7a1a6b8d37a1b45756dfe61b6b1b70e21cf047a4b7b93d3d521cf78bd6dd16a180d60cc458d5f80a')
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+}

--- a/BioArchLinux/r-cmprsk/lilac.py
+++ b/BioArchLinux/r-cmprsk/lilac.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+from lilaclib import *
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+def pre_build():
+    r_pre_build(_G)
+def post_build():
+    git_pkgbuild_commit()
+    update_aur_repo()

--- a/BioArchLinux/r-cmprsk/lilac.yaml
+++ b/BioArchLinux/r-cmprsk/lilac.yaml
@@ -1,0 +1,10 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: chrislongros
+  email: chris.longros@gmail.com
+update_on:
+- source: rpkgs
+  pkgname: cmprsk
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
Add CRAN package `cmprsk` 2.2-12.

Estimation, testing and regression modeling of subdistribution
functions in competing risks. Implements Gray (1988) K-sample tests
and Fine-Gray proportional hazards for competing risks.

Pure-R + Fortran, no r-* deps (uses base `survival` from R-Recommended).

Verification:
- makepkg --verifysource
- makepkg -f (clean build)