### PR TITLE
r-skimr: init pkg

### DIFF
--- a/BioArchLinux/r-skimr/PKGBUILD
+++ b/BioArchLinux/r-skimr/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=skimr
+_pkgver=2.2.2
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc='Compact and Flexible Summaries of Data'
+arch=(any)
+url="https://docs.ropensci.org/skimr/"
+license=('GPL-3.0-only')
+depends=(
+  r-cli
+  r-dplyr
+  r-knitr
+  r-pillar
+  r-purrr
+  r-repr
+  r-rlang
+  r-stringr
+  r-tibble
+  r-tidyr
+  r-tidyselect
+  r-vctrs
+)
+optdepends=(
+  r-data.table
+  r-dtplyr
+  r-extrafont
+  r-haven
+  r-lubridate
+  r-rmarkdown
+  r-testthat
+  r-withr
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('52badf9ea532763836255f059686eaeb')
+b2sums=('2e0d3d6af761c59914a89e78de74bafa2f8b69797f4ecaa01fade20fe2937bb35302cadbd90f1fe56d5e036f8a29bc4b082e3355ee052012f924ef725ab8888b')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}
+# vim:set ts=2 sw=2 et:

--- a/BioArchLinux/r-skimr/lilac.py
+++ b/BioArchLinux/r-skimr/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-skimr/lilac.yaml
+++ b/BioArchLinux/r-skimr/lilac.yaml
@@ -1,0 +1,23 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+repo_depends:
+- r-cli
+- r-dplyr
+- r-knitr
+- r-pillar
+- r-purrr
+- r-repr
+- r-rlang
+- r-stringr
+- r-tibble
+- r-tidyr
+- r-tidyselect
+- r-vctrs
+update_on:
+- source: rpkgs
+  pkgname: skimr
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
`r-skimr` provides compact, flexible summaries of data frames and vectors for use with pipes and pretty console output (CRAN 2.2.2, GPL-3, no compilation).

Verification:

- `python -m py_compile BioArchLinux/r-skimr/lilac.py`
- `makepkg -f --verifysource` in `BioArchLinux/r-skimr`
- `makepkg -f` in `BioArchLinux/r-skimr`
- `git diff --check`
