### PR TITLE
r-xxhashlite: init pkg

### DIFF
--- a/BioArchLinux/r-xxhashlite/PKGBUILD
+++ b/BioArchLinux/r-xxhashlite/PKGBUILD
@@ -1,0 +1,31 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=xxhashlite
+_pkgver=0.2.2
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Extremely Fast Hashing of R Objects, Raw Data and Files using 'xxHash' Algorithms"
+arch=('x86_64')
+url="https://github.com/coolbutuseless/xxhashlite"
+license=('MIT')
+depends=(
+  r
+)
+optdepends=(
+  r-testthat
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('3ed21677c9a3061109986fef70673ee0')
+b2sums=('bb673b690a5d9404343bd522ad6665a19f6249bff250b054ecb34919bd73d26202adb0712a433a80251a9088dfa0d168b011cc5f5c7b599a0d23afa531359a8d')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+  install -Dm644 "${_pkgname}/LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+}
+# vim:set ts=2 sw=2 et:

--- a/BioArchLinux/r-xxhashlite/lilac.py
+++ b/BioArchLinux/r-xxhashlite/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-xxhashlite/lilac.yaml
+++ b/BioArchLinux/r-xxhashlite/lilac.yaml
@@ -1,0 +1,10 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+update_on:
+- source: rpkgs
+  pkgname: xxhashlite
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
`r-xxhashlite` provides extremely fast hashing of R objects, raw bytes, and files using the xxHash C library (CRAN 0.2.2, MIT). NeedsCompilation, so `arch=('x86_64')`.

Verification:

- `python -m py_compile BioArchLinux/r-xxhashlite/lilac.py`
- `makepkg -f --verifysource` in `BioArchLinux/r-xxhashlite`
- `makepkg -f` in `BioArchLinux/r-xxhashlite`
- `git diff --check`
