### PR TITLE
r-cspp r-csppdata: init pkgs

### DIFF
--- a/BioArchLinux/r-cspp/PKGBUILD
+++ b/BioArchLinux/r-cspp/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=cspp
+_pkgver=0.3.3
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="A Tool for the Correlates of State Policy Project Data"
+arch=(any)
+url="https://github.com/correlatesstatepolicy/cspp"
+license=('GPL-3.0-or-later')
+depends=(
+  r-csppdata
+  r-dplyr
+  r-ggcorrplot
+  r-ggplot2
+  r-haven
+  r-mapproj
+  r-purrr
+  r-readr
+  r-rlang
+  r-stringr
+  r-tidyselect
+)
+optdepends=(
+  r-ggraph
+  r-igraph
+  r-knitr
+  r-rmarkdown
+  r-testthat
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('3dead19cb3e2cbf178473589865600f6')
+b2sums=('6bdafdb9af4c05d6f704ae7671581ced07e064685950e6b3870b4ff92c78f17ef479666d7a9104d0ea7924dc2c708f5a354f4736a2cb0f6566af056cb0dfc1bc')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}

--- a/BioArchLinux/r-cspp/lilac.py
+++ b/BioArchLinux/r-cspp/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-cspp/lilac.yaml
+++ b/BioArchLinux/r-cspp/lilac.yaml
@@ -1,0 +1,22 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+repo_depends:
+- r-csppdata
+- r-dplyr
+- r-ggcorrplot
+- r-ggplot2
+- r-haven
+- r-mapproj
+- r-purrr
+- r-readr
+- r-rlang
+- r-stringr
+- r-tidyselect
+update_on:
+- source: rpkgs
+  pkgname: cspp
+  repo: cran
+  md5: true
+- alias: r

--- a/BioArchLinux/r-csppdata/PKGBUILD
+++ b/BioArchLinux/r-csppdata/PKGBUILD
@@ -9,7 +9,6 @@ pkgdesc="Data Only: The Correlates of State Policy Project Dataset"
 arch=(any)
 url="https://github.com/correlatesstatepolicy/csppData"
 license=('GPL-3.0-only')
-depends=(r)
 source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 md5sums=('077133704fb3cdce6bfa04f35e61fa27')
 b2sums=('bb240882e1c5008589b2922f7c27246437afb601c1d89f3b5b98f7bec5e12a537126b32ff5840071bc8da0671b8f725d7f8e67112a77560f39f03af54b6e6143')

--- a/BioArchLinux/r-csppdata/PKGBUILD
+++ b/BioArchLinux/r-csppdata/PKGBUILD
@@ -1,0 +1,24 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=csppData
+_pkgver=0.2.61
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Data Only: The Correlates of State Policy Project Dataset"
+arch=(any)
+url="https://github.com/correlatesstatepolicy/csppData"
+license=('GPL-3.0-only')
+depends=(r)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('077133704fb3cdce6bfa04f35e61fa27')
+b2sums=('bb240882e1c5008589b2922f7c27246437afb601c1d89f3b5b98f7bec5e12a537126b32ff5840071bc8da0671b8f725d7f8e67112a77560f39f03af54b6e6143')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}

--- a/BioArchLinux/r-csppdata/lilac.py
+++ b/BioArchLinux/r-csppdata/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-csppdata/lilac.yaml
+++ b/BioArchLinux/r-csppdata/lilac.yaml
@@ -1,0 +1,10 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+update_on:
+- source: rpkgs
+  pkgname: csppData
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
Add CRAN packages `cspp` 0.3.3 and `csppData` 0.2.61.

`cspp` provides tools to import, subset, visualize, and export Correlates of State Policy Project data. `csppData` contains the dataset and codebook used by `cspp`.

Verification:
- `python -m py_compile BioArchLinux/r-cspp/lilac.py BioArchLinux/r-csppdata/lilac.py`
- `makepkg -f --verifysource` for `r-csppdata`
- `makepkg -f` for `r-csppdata`
- `makepkg -f --verifysource` for `r-cspp`
- `R_LIBS=/tmp/cspp-r-lib makepkg -f -d` for `r-cspp`, using a temporary R library with locally installed `csppData`, `maps`, and `mapproj`
