### PR TITLE
r-tidycensus r-tigris: init pkgs

### DIFF
--- a/BioArchLinux/r-tidycensus/PKGBUILD
+++ b/BioArchLinux/r-tidycensus/PKGBUILD
@@ -1,0 +1,47 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=tidycensus
+_pkgver=1.7.5
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Load US Census Boundary and Attribute Data as Tidyverse and sf-Ready Data Frames"
+arch=(any)
+url="https://walker-data.com/tidycensus/"
+license=('MIT')
+depends=(
+  r-crayon
+  r-dplyr
+  r-httr
+  r-jsonlite
+  r-purrr
+  r-rappdirs
+  r-readr
+  r-rlang
+  r-rvest
+  r-sf
+  r-stringr
+  r-tidyr
+  r-tidyselect
+  r-tigris
+  r-units
+  r-xml2
+)
+optdepends=(
+  r-ggplot2
+  r-survey
+  r-terra
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('3d9ddf56c71f221e50ac444963bdc391')
+b2sums=('3efc1d03de5e6227897dcc26a8952924119610454bfba16d9a6c2624376a323a96f688b41f84fe86bd9f1275b383aad21386ff0ae74123ba3ed99ec61a1aa492')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+  install -Dm644 "${_pkgname}/LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+}

--- a/BioArchLinux/r-tidycensus/lilac.py
+++ b/BioArchLinux/r-tidycensus/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-tidycensus/lilac.yaml
+++ b/BioArchLinux/r-tidycensus/lilac.yaml
@@ -1,0 +1,27 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+repo_depends:
+- r-crayon
+- r-dplyr
+- r-httr
+- r-jsonlite
+- r-purrr
+- r-rappdirs
+- r-readr
+- r-rlang
+- r-rvest
+- r-sf
+- r-stringr
+- r-tidyr
+- r-tidyselect
+- r-tigris
+- r-units
+- r-xml2
+update_on:
+- source: rpkgs
+  pkgname: tidycensus
+  repo: cran
+  md5: true
+- alias: r

--- a/BioArchLinux/r-tigris/PKGBUILD
+++ b/BioArchLinux/r-tigris/PKGBUILD
@@ -1,0 +1,41 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=tigris
+_pkgver=2.2.1
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Load Census TIGER/Line Shapefiles"
+arch=(any)
+url="https://github.com/walkerke/tigris"
+license=('MIT')
+depends=(
+  r-dplyr
+  r-httr
+  r-magrittr
+  r-rappdirs
+  r-sf
+  r-stringr
+  r-uuid
+)
+optdepends=(
+  r-ggplot2
+  r-ggthemes
+  r-knitr
+  r-leaflet
+  r-sp
+  r-testthat
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('8a74612cc32d657429efcd6b40d5f087')
+b2sums=('3b9e92c0e3b719a51dd4286ca69ee0ec72114bc92113ee394d22fb917006bb9790fcc08a9722b05ac27f90884925c8cfd644db9f11f496ac2e46cc4074944c20')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+  install -Dm644 "${_pkgname}/LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+}

--- a/BioArchLinux/r-tigris/lilac.py
+++ b/BioArchLinux/r-tigris/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-tigris/lilac.yaml
+++ b/BioArchLinux/r-tigris/lilac.yaml
@@ -1,0 +1,18 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+repo_depends:
+- r-dplyr
+- r-httr
+- r-magrittr
+- r-rappdirs
+- r-sf
+- r-stringr
+- r-uuid
+update_on:
+- source: rpkgs
+  pkgname: tigris
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
Add CRAN packages `tidycensus` 1.7.5 and `tigris` 2.2.1.

`tidycensus` provides an R interface to US Census APIs and boundary data. `tigris` loads Census TIGER/Line shapefiles and is a runtime dependency of `tidycensus`.

Verification:
- `python -m py_compile BioArchLinux/r-tigris/lilac.py BioArchLinux/r-tidycensus/lilac.py`
- `makepkg -f --verifysource` for `r-tigris`
- `makepkg -f` for `r-tigris`
- `makepkg -f --verifysource` for `r-tidycensus`
- `R_LIBS=/tmp/tidycensus-r-lib makepkg -f -d` for `r-tidycensus`, using a temporary R library with locally installed `tigris`
