### PR TITLE
r-ellmer: init pkg

### DIFF
--- a/BioArchLinux/r-ellmer/PKGBUILD
+++ b/BioArchLinux/r-ellmer/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=ellmer
+_pkgver=0.4.1
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc='Chat with Large Language Models'
+arch=(any)
+url="https://ellmer.tidyverse.org"
+license=('MIT')
+depends=(
+  r-cli
+  r-coro
+  r-glue
+  r-httr2
+  r-jsonlite
+  r-later
+  r-lifecycle
+  r-promises
+  r-r6
+  r-rlang
+  r-s7
+  r-tibble
+  r-vctrs
+)
+optdepends=(
+  r-curl
+  r-gargle
+  r-gitcreds
+  r-jose
+  r-knitr
+  r-magick
+  r-openssl
+  r-otel
+  r-paws.common
+  r-png
+  r-rmarkdown
+  r-shiny
+  r-testthat
+  r-withr
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('a11255f800934e0d34d4b0ea64f75350')
+b2sums=('912327f303eb93919968d62420f456cc090163905629bab3a5cc90edd8f2066581f36113fe2b63d7d058ad0d442d0d7be367f17e59241df01c678eea4c22499d')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+  install -Dm644 "${_pkgname}/LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+}

--- a/BioArchLinux/r-ellmer/lilac.py
+++ b/BioArchLinux/r-ellmer/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-ellmer/lilac.yaml
+++ b/BioArchLinux/r-ellmer/lilac.yaml
@@ -1,0 +1,25 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+pre_build: lilac_r_utils.r_pre_build
+
+repo_depends:
+  - r-cli
+  - r-coro
+  - r-glue
+  - r-httr2
+  - r-jsonlite
+  - r-later
+  - r-lifecycle
+  - r-promises
+  - r-r6
+  - r-rlang
+  - r-s7
+  - r-tibble
+  - r-vctrs
+
+update_on:
+  - source: rpkgs
+    pkg: ellmer
+    md5: true


### PR DESCRIPTION
Adds `r-ellmer` 0.4.1 (CRAN), a tidyverse package for chatting with LLMs (Claude, OpenAI, Gemini, etc.) with streaming, tool calling, and structured output.

- License: MIT
- `NeedsCompilation: no` → `arch=(any)`
- All `Imports` already available in BioArchLinux (r-cli, r-coro, r-glue, r-httr2, r-jsonlite, r-later, r-lifecycle, r-promises, r-r6, r-rlang, r-s7, r-tibble, r-vctrs)
- Built and installed locally via `makepkg -f`