### PR TITLE
r-ellmer: fix pkgname in lilac.yaml and restore pkgver in PKGBUILD

### DIFF
--- a/BioArchLinux/r-ellmer/PKGBUILD
+++ b/BioArchLinux/r-ellmer/PKGBUILD
@@ -3,7 +3,7 @@
 _pkgname=ellmer
 _pkgver=0.4.1
 pkgname=r-${_pkgname,,}
-pkgver=None
+pkgver=${_pkgver//-/.}
 pkgrel=1
 pkgdesc='Chat with Large Language Models'
 arch=(any)

--- a/BioArchLinux/r-ellmer/lilac.yaml
+++ b/BioArchLinux/r-ellmer/lilac.yaml
@@ -22,7 +22,7 @@ repo_depends:
   - r-vctrs
 update_on:
   - source: rpkgs
-    pkg: ellmer
+    pkgname: ellmer
     repo: cran
     md5: true
   - alias: r


### PR DESCRIPTION
Two fixes:

1. `pkg: ellmer` → `pkgname: ellmer` in `lilac.yaml` — nvchecker's `rpkgs` source reads `pkgname`, not `pkg`. With the wrong field name, nvchecker falls back to the package base name `r-ellmer`, which doesn't exist on CRAN, causing the repeated `GetVersionError`.

2. `pkgver=None` → `pkgver=${_pkgver//-/.}` in `PKGBUILD` — Lilac wrote `None` as the version when a previous build ran with `_G.newver = None` (a side effect of the issue fixed in #341). Restores the correct dynamic assignment.