### PR TITLE
r-ellmer: restore lilac.py with r_pre_build to handle md5 version strings

### DIFF
--- a/BioArchLinux/r-ellmer/lilac.py
+++ b/BioArchLinux/r-ellmer/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-ellmer/lilac.yaml
+++ b/BioArchLinux/r-ellmer/lilac.yaml
@@ -2,10 +2,6 @@ build_prefix: extra-x86_64
 maintainers:
   - github: bshor
     email: boris@bshor.com
-pre_build_script: |
-  update_pkgver_and_pkgrel(_G.newver)
-post_build_script: |
-  git_pkgbuild_commit()
 repo_depends:
   - r-cli
   - r-coro


### PR DESCRIPTION
The inline `pre_build_script: update_pkgver_and_pkgrel(_G.newver)` doesn't handle the `#md5` suffix that nvchecker appends when `md5: true` is set, causing the package to be published as `0.4.1#a11255f800934e0d34d4b0ea64f75350-1` instead of `0.4.1-1`.

Restoring `lilac.py` with `r_pre_build`, which correctly splits the version and md5 via `_G.newver.rsplit("#", 1)`. The inline scripts are removed from `lilac.yaml` to avoid the conflict that caused issues in #341.