### PR TITLE
r-ellmer: fix pkgver and bump pkgrel to force rebuild

### DIFF
--- a/BioArchLinux/r-ellmer/PKGBUILD
+++ b/BioArchLinux/r-ellmer/PKGBUILD
@@ -3,8 +3,8 @@
 _pkgname=ellmer
 _pkgver=0.4.1
 pkgname=r-${_pkgname,,}
-pkgver=0.4.1#a11255f800934e0d34d4b0ea64f75350
-pkgrel=1
+pkgver=${_pkgver//-/.}
+pkgrel=2
 pkgdesc='Chat with Large Language Models'
 arch=(any)
 url="https://ellmer.tidyverse.org"


### PR DESCRIPTION
Lilac previously wrote `pkgver=0.4.1#a11255f800934e0d34d4b0ea64f75350` into the PKGBUILD when the md5 handling was broken (before #343). This restores `pkgver=${_pkgver//-/.}` and bumps `pkgrel` to 2 to force a fresh build with the now-correct `lilac.py`.