### PR TITLE
r-qualtrics: init pkg

### DIFF
--- a/BioArchLinux/r-ellmer/PKGBUILD
+++ b/BioArchLinux/r-ellmer/PKGBUILD
@@ -3,8 +3,8 @@
 _pkgname=ellmer
 _pkgver=0.4.1
 pkgname=r-${_pkgname,,}
-pkgver=0.4.1#a11255f800934e0d34d4b0ea64f75350
-pkgrel=1
+pkgver=${_pkgver//-/.}
+pkgrel=2
 pkgdesc='Chat with Large Language Models'
 arch=(any)
 url="https://ellmer.tidyverse.org"

--- a/BioArchLinux/r-qualtrics/PKGBUILD
+++ b/BioArchLinux/r-qualtrics/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=qualtRics
+_pkgver=3.2.2
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc='Download Qualtrics Survey Data'
+arch=(any)
+url="https://docs.ropensci.org/qualtRics/"
+license=('MIT')
+depends=(
+  r-archive
+  r-cli
+  r-dplyr
+  r-fs
+  r-glue
+  r-httr
+  r-jsonlite
+  r-lifecycle
+  r-lubridate
+  r-purrr
+  r-readr
+  r-rlang
+  r-sjlabelled
+  r-stringr
+  r-tibble
+  r-tidyr
+  r-withr
+)
+optdepends=(
+  r-knitr
+  r-rmarkdown
+  r-testthat
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('8ff3ba7d4c238ff2b2cf8dff1d2af59a')
+b2sums=('3e3e657cff778207824a3a3bdecea55b63885e80bde1e2567e99b96abdbb166958c14e89eb67df4c310db587f51ad2e16aa6c15f77dfe05dae683eeed17fad8d')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+  install -Dm644 "${_pkgname}/LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+}

--- a/BioArchLinux/r-qualtrics/lilac.py
+++ b/BioArchLinux/r-qualtrics/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-qualtrics/lilac.yaml
+++ b/BioArchLinux/r-qualtrics/lilac.yaml
@@ -1,0 +1,28 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-archive
+  - r-cli
+  - r-dplyr
+  - r-fs
+  - r-glue
+  - r-httr
+  - r-jsonlite
+  - r-lifecycle
+  - r-lubridate
+  - r-purrr
+  - r-readr
+  - r-rlang
+  - r-sjlabelled
+  - r-stringr
+  - r-tibble
+  - r-tidyr
+  - r-withr
+update_on:
+  - source: rpkgs
+    pkgname: qualtRics
+    repo: cran
+    md5: true
+  - alias: r


### PR DESCRIPTION
Adds `r-qualtrics` 3.2.2 (CRAN package `qualtRics`), an rOpenSci package for downloading Qualtrics survey data via their API.

- License: MIT
- `NeedsCompilation: no` → `arch=(any)`
- All `Imports` already available in BioArchLinux
- Built and installed locally via `makepkg -f`