### PR TITLE
r-keyatm r-matrixnormal r-pgdraw: init pkgs

### DIFF
--- a/BioArchLinux/r-keyatm/PKGBUILD
+++ b/BioArchLinux/r-keyatm/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=keyATM
+_pkgver=0.5.5
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc='Keyword Assisted Topic Models'
+arch=('x86_64')
+url="https://keyatm.github.io/keyATM/"
+license=('GPL-3.0-only')
+depends=(
+  r-cli
+  r-dplyr
+  r-fastmap
+  r-fs
+  r-future.apply
+  r-ggplot2
+  r-ggrepel
+  r-magrittr
+  r-matrixnormal
+  r-pgdraw
+  r-purrr
+  r-quanteda
+  r-rcpp
+  r-rcppeigen
+  r-rlang
+  r-stringr
+  r-tibble
+  r-tidyr
+  r-tidyselect
+)
+optdepends=(
+  r-knitr
+  r-rmarkdown
+  r-testthat
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('73d43d96e462910e1e9ed352791f9444')
+b2sums=('a0bb2f6cd2933e4595907bdef66d96238bcf5b91bc3db62264fa21fe775284801a9b3dc864b40c08c0121b95f46c2254ece9ad12e6f435270caacbb276ca631c')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}

--- a/BioArchLinux/r-keyatm/lilac.py
+++ b/BioArchLinux/r-keyatm/lilac.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(
+        _G,
+        expect_systemrequirements='C++17',
+    )
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-keyatm/lilac.yaml
+++ b/BioArchLinux/r-keyatm/lilac.yaml
@@ -1,0 +1,30 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-cli
+  - r-dplyr
+  - r-fastmap
+  - r-fs
+  - r-future.apply
+  - r-ggplot2
+  - r-ggrepel
+  - r-magrittr
+  - r-matrixnormal
+  - r-pgdraw
+  - r-purrr
+  - r-quanteda
+  - r-rcpp
+  - r-rcppeigen
+  - r-rlang
+  - r-stringr
+  - r-tibble
+  - r-tidyr
+  - r-tidyselect
+update_on:
+  - source: rpkgs
+    pkgname: keyATM
+    repo: cran
+    md5: true
+  - alias: r

--- a/BioArchLinux/r-matrixnormal/PKGBUILD
+++ b/BioArchLinux/r-matrixnormal/PKGBUILD
@@ -1,0 +1,26 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=matrixNormal
+_pkgver=0.1.2
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc='The Matrix Normal Distribution'
+arch=(any)
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('GPL-3.0-only')
+depends=(
+  r-mvtnorm
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('004ff646354de6ef747f510127009e1e')
+b2sums=('0018d1a69b3c7ab04d2987fb6d3494a08fda4b97450f3ffbaf42d89ebb2016a81e02aa08a415ddae909b0f31ac54f0cf739ab76e07411fa561e96a6291749d78')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}

--- a/BioArchLinux/r-matrixnormal/PKGBUILD
+++ b/BioArchLinux/r-matrixnormal/PKGBUILD
@@ -12,6 +12,17 @@ license=('GPL-3.0-only')
 depends=(
   r-mvtnorm
 )
+optdepends=(
+  r-formatr
+  r-knitr
+  r-laplacesdemon
+  r-matrixcalc
+  r-rmarkdown
+  r-roxygen2
+  r-sessioninfo
+  r-spelling
+  r-testthat
+)
 source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 md5sums=('004ff646354de6ef747f510127009e1e')
 b2sums=('0018d1a69b3c7ab04d2987fb6d3494a08fda4b97450f3ffbaf42d89ebb2016a81e02aa08a415ddae909b0f31ac54f0cf739ab76e07411fa561e96a6291749d78')

--- a/BioArchLinux/r-matrixnormal/lilac.py
+++ b/BioArchLinux/r-matrixnormal/lilac.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()
+

--- a/BioArchLinux/r-matrixnormal/lilac.yaml
+++ b/BioArchLinux/r-matrixnormal/lilac.yaml
@@ -1,0 +1,12 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-mvtnorm
+update_on:
+  - source: rpkgs
+    pkgname: matrixNormal
+    repo: cran
+    md5: true
+  - alias: r

--- a/BioArchLinux/r-pgdraw/PKGBUILD
+++ b/BioArchLinux/r-pgdraw/PKGBUILD
@@ -1,0 +1,26 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=pgdraw
+_pkgver=1.1
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc='Generate Random Samples from the Polya-Gamma Distribution'
+arch=('x86_64')
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('GPL-3.0-or-later')
+depends=(
+  r-rcpp
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('1e36c651849bf3ff87d8446bebfbe1b3')
+b2sums=('45893c9a316f99de58a014cfcf5697d04f3e8d1675270ee3007a3c7e1b18ecabf7254b7f2181ab9e88bbf93f69645c48d4ad72144ca889a5c814b8381cffc618')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}

--- a/BioArchLinux/r-pgdraw/lilac.py
+++ b/BioArchLinux/r-pgdraw/lilac.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()
+

--- a/BioArchLinux/r-pgdraw/lilac.yaml
+++ b/BioArchLinux/r-pgdraw/lilac.yaml
@@ -1,0 +1,12 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-rcpp
+update_on:
+  - source: rpkgs
+    pkgname: pgdraw
+    repo: cran
+    md5: true
+  - alias: r


### PR DESCRIPTION
Adds `r-keyatm` 0.5.5 and its two missing dependencies.

`keyATM` (Keyword Assisted Topic Models) is an R package for fitting topic models that incorporate user-provided keywords to guide topic discovery, improving interpretability over standard LDA.

| Package | Version | License | Notes |
|---|---|---|---|
| `r-keyatm` | 0.5.5 | GPL-3 | Keyword assisted topic models; NeedsCompilation: yes; C++17 |
| `r-matrixnormal` | 0.1.2 | GPL-3 | Matrix normal distribution |
| `r-pgdraw` | 1.1 | GPL (>= 3) | Polya-Gamma sampler; NeedsCompilation: yes |

All other `r-keyatm` Imports were already in BioArchLinux. Built and verified locally via `makepkg -f`.