### PR TITLE
r-shinychat: init pkg

### DIFF
--- a/BioArchLinux/r-shinychat/PKGBUILD
+++ b/BioArchLinux/r-shinychat/PKGBUILD
@@ -1,0 +1,47 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=shinychat
+_pkgver=0.4.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Chat UI Component for 'shiny'"
+arch=(any)
+url="https://github.com/posit-dev/shinychat"
+license=('MIT')
+depends=(
+  r-base64enc
+  r-bslib
+  r-cli
+  r-coro
+  r-ellmer
+  r-fastmap
+  r-htmltools
+  r-jsonlite
+  r-lifecycle
+  r-promises
+  r-rlang
+  r-s7
+  r-shiny
+)
+optdepends=(
+  r-covr
+  r-knitr
+  r-later
+  r-r6
+  r-testthat
+  r-withr
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('7879149128a3de496f25a98c251ab06c')
+b2sums=('fb1c0c5f420365a6a3ac2a89fe05a7f0dcb3a71067b398079a838ccf685d5ba6e7b6a06fc215f86aafd7b182ab08a2470ead678c24cb718fbbabf848b3f934f0')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+  install -Dm644 "${_pkgname}/LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+}

--- a/BioArchLinux/r-shinychat/lilac.py
+++ b/BioArchLinux/r-shinychat/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-shinychat/lilac.yaml
+++ b/BioArchLinux/r-shinychat/lilac.yaml
@@ -1,0 +1,24 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-base64enc
+  - r-bslib
+  - r-cli
+  - r-coro
+  - r-ellmer
+  - r-fastmap
+  - r-htmltools
+  - r-jsonlite
+  - r-lifecycle
+  - r-promises
+  - r-rlang
+  - r-s7
+  - r-shiny
+update_on:
+  - source: rpkgs
+    pkgname: shinychat
+    repo: cran
+    md5: true
+  - alias: r


### PR DESCRIPTION
Add CRAN package `shinychat` 0.4.0.

`shinychat` provides a scrolling chat interface for Shiny applications,
including chatbot apps that use `ellmer` to call large language models.

Verification:
- `git diff --check`
- `git diff --check --cached`
- `bash -n BioArchLinux/r-shinychat/PKGBUILD`
- `python -m py_compile BioArchLinux/r-shinychat/lilac.py`
- `makepkg --verifysource`
- `makepkg -Cfd`
