### PR TITLE
r-btw deps: init pkgs

### DIFF
--- a/BioArchLinux/r-btw/PKGBUILD
+++ b/BioArchLinux/r-btw/PKGBUILD
@@ -1,0 +1,72 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=btw
+_pkgver=1.2.1
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc='A Toolkit for Connecting R and Large Language Models'
+arch=(any)
+url="https://github.com/posit-dev/btw"
+license=('MIT')
+depends=(
+  r-brio
+  r-cli
+  r-clipr
+  r-dplyr
+  r-ellmer
+  r-frontmatter
+  r-fs
+  r-jsonlite
+  r-lifecycle
+  r-mcptools
+  r-pkgsearch
+  r-rlang
+  r-rmarkdown
+  r-rstudioapi
+  r-s7
+  r-sessioninfo
+  r-skimr
+  r-withr
+  r-xml2
+)
+optdepends=(
+  r-bslib
+  r-callr
+  r-chromote
+  r-covr
+  r-dbi
+  r-devtools
+  r-diffviewer
+  r-duckdb
+  r-evaluate
+  r-fansi
+  r-gert
+  r-gh
+  r-htmltools
+  r-pandoc
+  r-pkgload
+  r-processx
+  r-ragg
+  r-rapp
+  r-roxygen2
+  r-shiny
+  r-shinychat
+  r-testthat
+  r-tibble
+  r-usethis
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('e611c3dcfaa9a8bd6918cb20f02f570a')
+b2sums=('fbe941ab27c96a504de5fd104e1740cf8115005a5782184e806428f59a22ced70e2c88b0f7785057c108b7d5451c378b809e3c346e9376b1cda1e05c2e1fe790')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "${_pkgname}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/${_pkgname}" "${pkgdir}/usr/lib/R/library"
+  install -Dm644 "${_pkgname}/LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+}

--- a/BioArchLinux/r-btw/lilac.py
+++ b/BioArchLinux/r-btw/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-btw/lilac.yaml
+++ b/BioArchLinux/r-btw/lilac.yaml
@@ -1,0 +1,30 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-brio
+  - r-cli
+  - r-clipr
+  - r-dplyr
+  - r-ellmer
+  - r-frontmatter
+  - r-fs
+  - r-jsonlite
+  - r-lifecycle
+  - r-mcptools
+  - r-pkgsearch
+  - r-rlang
+  - r-rmarkdown
+  - r-rstudioapi
+  - r-s7
+  - r-sessioninfo
+  - r-skimr
+  - r-withr
+  - r-xml2
+update_on:
+  - source: rpkgs
+    pkgname: btw
+    repo: cran
+    md5: true
+  - alias: r

--- a/BioArchLinux/r-frontmatter/PKGBUILD
+++ b/BioArchLinux/r-frontmatter/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=frontmatter
+_pkgver=0.2.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc='Parse Front Matter from Documents'
+arch=('x86_64')
+url="https://github.com/posit-dev/frontmatter"
+license=('MIT')
+depends=(
+  r-cpp11
+  r-rlang
+  r-tomledit
+  r-yaml12
+)
+optdepends=(
+  r-testthat
+  r-withr
+  r-yaml
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('e4d1c9d29c3d5914ac624465bb2305db')
+b2sums=('c03895771014a24e6bc7e4b4f5b506afe0099efbd43ffc1257052085210eaf96562b857b3d32665fdf3e4c5cfaae698d9a4586dfeac4982e1af3cb7967bcfb9f')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "${_pkgname}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/${_pkgname}" "${pkgdir}/usr/lib/R/library"
+  install -Dm644 "${_pkgname}/LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+}

--- a/BioArchLinux/r-frontmatter/lilac.py
+++ b/BioArchLinux/r-frontmatter/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-frontmatter/lilac.yaml
+++ b/BioArchLinux/r-frontmatter/lilac.yaml
@@ -1,0 +1,15 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-cpp11
+  - r-rlang
+  - r-tomledit
+  - r-yaml12
+update_on:
+  - source: rpkgs
+    pkgname: frontmatter
+    repo: cran
+    md5: true
+  - alias: r

--- a/BioArchLinux/r-mcptools/PKGBUILD
+++ b/BioArchLinux/r-mcptools/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=mcptools
+_pkgver=0.2.1
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc='Model Context Protocol Servers and Clients'
+arch=(any)
+url="https://github.com/posit-dev/mcptools"
+license=('MIT')
+depends=(
+  r-cli
+  r-ellmer
+  r-httpuv
+  r-httr2
+  r-jsonlite
+  r-nanonext
+  r-processx
+  r-promises
+  r-rlang
+)
+optdepends=(
+  r-knitr
+  r-rmarkdown
+  r-testthat
+  r-withr
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('43e44dff3b4b5713fdd077f3a7b85314')
+b2sums=('e6bd08a3b1d7c1d419a84b1481f1f259cb5c4377beaa2cfb56557463fa22434428ba803b4ed6c52523f8646bbe2ec8b2df44574b2b5a6cb99ffcf17c6de86861')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "${_pkgname}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/${_pkgname}" "${pkgdir}/usr/lib/R/library"
+  install -Dm644 "${_pkgname}/LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+}

--- a/BioArchLinux/r-mcptools/lilac.py
+++ b/BioArchLinux/r-mcptools/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-mcptools/lilac.yaml
+++ b/BioArchLinux/r-mcptools/lilac.yaml
@@ -1,0 +1,20 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-cli
+  - r-ellmer
+  - r-httpuv
+  - r-httr2
+  - r-jsonlite
+  - r-nanonext
+  - r-processx
+  - r-promises
+  - r-rlang
+update_on:
+  - source: rpkgs
+    pkgname: mcptools
+    repo: cran
+    md5: true
+  - alias: r

--- a/BioArchLinux/r-tomledit/PKGBUILD
+++ b/BioArchLinux/r-tomledit/PKGBUILD
@@ -1,0 +1,31 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=tomledit
+_pkgver=0.1.1
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Parse, Read, and Edit 'TOML'"
+arch=('x86_64')
+url="https://github.com/extendr/tomledit"
+license=('MIT')
+depends=(
+  r-rlang
+)
+makedepends=(
+  rust
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('78a86fbb82d549d766ed2a727c01386d')
+b2sums=('4c8eeb08eea508c0edb494996a1ceadf7762fd332ce3865ee3d2503404aee97a7fe20abb3fa0efb160a3e91b8c06182e5c17306557672703bc08fa383dc4ac05')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "${_pkgname}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/${_pkgname}" "${pkgdir}/usr/lib/R/library"
+  install -Dm644 "${_pkgname}/LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+}

--- a/BioArchLinux/r-tomledit/lilac.py
+++ b/BioArchLinux/r-tomledit/lilac.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(
+        _G,
+        expect_systemrequirements = "Cargo (Rust's package manager), rustc",
+    )
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-tomledit/lilac.yaml
+++ b/BioArchLinux/r-tomledit/lilac.yaml
@@ -1,0 +1,12 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-rlang
+update_on:
+  - source: rpkgs
+    pkgname: tomledit
+    repo: cran
+    md5: true
+  - alias: r

--- a/BioArchLinux/r-yaml12/PKGBUILD
+++ b/BioArchLinux/r-yaml12/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=yaml12
+_pkgver=0.1.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Fast 'YAML' 1.2 Parser and Formatter"
+arch=('x86_64')
+url="https://github.com/posit-dev/r-yaml12"
+license=('MIT')
+depends=(
+  r
+)
+makedepends=(
+  rust
+  xz
+)
+optdepends=(
+  r-jsonlite
+  r-knitr
+  r-rmarkdown
+  r-testthat
+  r-waldo
+  r-withr
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('b8267aa53b360269fab732d8d2c04e90')
+b2sums=('93f7e8dbd66705de6afc8ba70f3b0f37b7d710d3267c42254efd7021689c6dcde7afb251459149a64fbb5673be7a9a74f2af91677e72f5118d9e40d3e5c6dd63')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "${_pkgname}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/${_pkgname}" "${pkgdir}/usr/lib/R/library"
+  install -Dm644 "${_pkgname}/LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+}

--- a/BioArchLinux/r-yaml12/lilac.py
+++ b/BioArchLinux/r-yaml12/lilac.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(
+        _G,
+        expect_systemrequirements = "Cargo (Rust's package manager), rustc >= 1.70.0, xz",
+    )
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-yaml12/lilac.yaml
+++ b/BioArchLinux/r-yaml12/lilac.yaml
@@ -1,0 +1,10 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+update_on:
+  - source: rpkgs
+    pkgname: yaml12
+    repo: cran
+    md5: true
+  - alias: r


### PR DESCRIPTION
Adds `r-btw`, a toolkit for connecting R and large language models, together
with its missing runtime dependency chain.

Included packages:

- `r-btw` 1.2.1
- `r-mcptools` 0.2.1
- `r-frontmatter` 0.2.0
- `r-tomledit` 0.1.1
- `r-yaml12` 0.1.0

Verification:

- `makepkg --verifysource` for all five packages
- `makepkg -Cfd` bottom-up for all five packages, using a temporary R library
  for the local dependency chain
- `bash -n` for all five `PKGBUILD` files
- `python -m py_compile` for all five `lilac.py` files
- YAML parse check for all five `lilac.yaml` files
- `git diff --cached --check`
