### PR TITLE
r-dsl r-grf r-dicekriging: init pkgs

### DIFF
--- a/BioArchLinux/r-dicekriging/PKGBUILD
+++ b/BioArchLinux/r-dicekriging/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=DiceKriging
+_pkgver=1.6.1
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Kriging Methods for Computer Experiments"
+arch=('x86_64')
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('GPL-2.0-only' 'GPL-3.0-only')
+depends=(
+  r
+)
+optdepends=(
+  r-doparallel
+  r-foreach
+  r-numderiv
+  r-rgenoud
+  r-testthat
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('43540ac986833443d68dba488598eafe')
+b2sums=('a608d27d445e857a881813628018e28a506786376d71eda586caee5c01295faf09c97f0ad8092bc7c43407b02219abe172bb2b5ae4349060ea49efcdc6980f1d')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}

--- a/BioArchLinux/r-dicekriging/lilac.py
+++ b/BioArchLinux/r-dicekriging/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-dicekriging/lilac.yaml
+++ b/BioArchLinux/r-dicekriging/lilac.yaml
@@ -1,0 +1,10 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+update_on:
+  - source: rpkgs
+    pkgname: DiceKriging
+    repo: cran
+    md5: true
+  - alias: r

--- a/BioArchLinux/r-dsl/PKGBUILD
+++ b/BioArchLinux/r-dsl/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=dsl
+_commit=537664a54163dda52ee277071fdfd9e8df2572a6
+pkgname=r-${_pkgname}
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="Design-based Supervised Learning"
+arch=(any)
+url="https://github.com/naoki-egami/dsl"
+license=('GPL-2.0-only')
+depends=(
+  r
+  r-arm
+  r-estimatr
+  r-grf
+  r-matrixcalc
+  r-superlearner
+  r-tidyverse
+)
+source=("${_pkgname}-${_commit}.tar.gz::${url}/archive/${_commit}.tar.gz")
+md5sums=('3d52bfb2175b65b7b2ca6a194d235737')
+b2sums=('70b1103ea3aa4720b5f9b5ccbc7621ce93872e330da942e478fd74c8f8633a3b300719df221f351f19090a4547c089d0ee453d66b681e967ef5cab97c3f018dc')
+
+build() {
+  R CMD INSTALL ${_pkgname}-${_commit} -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}

--- a/BioArchLinux/r-dsl/lilac.yaml
+++ b/BioArchLinux/r-dsl/lilac.yaml
@@ -1,0 +1,19 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-arm
+  - r-estimatr
+  - r-grf
+  - r-matrixcalc
+  - r-superlearner
+  - r-tidyverse
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver)
+post_build_script: |
+  git_pkgbuild_commit()
+update_on:
+  - source: manual
+    manual: '0.1.0'
+  - alias: r

--- a/BioArchLinux/r-grf/PKGBUILD
+++ b/BioArchLinux/r-grf/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=grf
+_pkgver=2.6.1
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Generalized Random Forests"
+arch=('x86_64')
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('GPL-3.0-only')
+depends=(
+  r
+  r-dicekriging
+  r-lmtest
+  r-rcpp
+  r-sandwich
+)
+makedepends=(
+  r-rcppeigen
+)
+optdepends=(
+  r-diagrammer
+  r-knitr
+  r-mass
+  r-policytree
+  r-rdrobust
+  r-rmarkdown
+  r-survival
+  r-testthat
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('5695490194b2e49efafbfe7ce68bd28c')
+b2sums=('b1552a47fad1328e971719f1824a77d226169d1df05654b5786c3dc7703273ec731cd1cebc49a0c9f8d2a700edf3c408f875bf65bbd749fcf3c52a52a6cece35')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}

--- a/BioArchLinux/r-grf/lilac.py
+++ b/BioArchLinux/r-grf/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-grf/lilac.yaml
+++ b/BioArchLinux/r-grf/lilac.yaml
@@ -1,0 +1,16 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-dicekriging
+  - r-lmtest
+  - r-rcpp
+  - r-rcppeigen
+  - r-sandwich
+update_on:
+  - source: rpkgs
+    pkgname: grf
+    repo: cran
+    md5: true
+  - alias: r


### PR DESCRIPTION
Add `r-dsl` (CRAN-style packaging of `naoki-egami/dsl`, Design-based
Supervised Learning by Egami, Hinck, Stewart, and Wei) along with its
two missing CRAN dependencies, `r-grf` and `r-dicekriging`.

`dsl` is not on CRAN and has no upstream tags/releases, so `r-dsl` is
pinned to upstream commit `537664a` (master HEAD as of 2025-07-22) with
`source: manual` set to `0.1.0`. The pin can be bumped if upstream
publishes a new commit or version.

Verification:
- `git diff --check` / `git diff --check --cached`
- `python -m py_compile BioArchLinux/r-{dicekriging,grf}/lilac.py`
- `bash -n` on all three PKGBUILDs
- `makepkg --verifysource` on all three
- `makepkg -Cfd` end-to-end build of all three (using temp R libraries
  for r-grf and r-dsl to satisfy in-PR dependencies)