### PR TITLE
r-grf: declare SystemRequirements

### DIFF
--- a/BioArchLinux/r-grf/lilac.py
+++ b/BioArchLinux/r-grf/lilac.py
@@ -7,7 +7,10 @@ sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
 from lilac_r_utils import r_pre_build
 
 def pre_build():
-    r_pre_build(_G)
+    r_pre_build(
+        _G,
+        expect_systemrequirements = "C++17, GNU make",
+    )
 
 def post_build():
     git_pkgbuild_commit()


### PR DESCRIPTION
Build failed with `SystemRequirements have changed: C++17, GNU make`. Declare it via `expect_systemrequirements` in lilac.py so the r_pre_build check passes.

Same pattern as r-alabaster.base and other packages with combined C++17/GNU make sysreqs.

Build log: https://build.bioarchlinux.org/api/pkg/r-grf/log/1781288434