### PR TITLE
r-zip: add r-cli makedepend for CRAN 3.0.0

### DIFF
--- a/BioArchLinux/r-zip/PKGBUILD
+++ b/BioArchLinux/r-zip/PKGBUILD
@@ -15,6 +15,9 @@ license=('MIT')
 depends=(
   r
 )
+makedepends=(
+  r-cli
+)
 checkdepends=(
   r-testthat
 )

--- a/BioArchLinux/r-zip/lilac.yaml
+++ b/BioArchLinux/r-zip/lilac.yaml
@@ -3,6 +3,7 @@ maintainers:
 - github: pekkarr
   email: pekkarr@protonmail.com
 repo_makedepends:
+- r-cli
 - r-testthat
 update_on:
 - source: rpkgs


### PR DESCRIPTION
CRAN zip 3.0.0 added `LinkingTo: cli`, which makes the lilac auto-update fail with `Missing make dependency: r-cli` during `r_pre_build`. Three consecutive auto-builds have failed for this reason.

Adding `r-cli` to `makedepends` (PKGBUILD) and `repo_makedepends` (lilac.yaml) unblocks the check so lilac can bump `pkgver` to 3.0.0 on the next run.

Failed build log: https://build.bioarchlinux.org/api/pkg/r-zip/log/1781482799

cc @pekkarr (maintainer)
