### PR TITLE
r-hrbrthemes: drop extrafont and gdtools depends for CRAN 0.9.3

### DIFF
--- a/BioArchLinux/r-hrbrthemes/PKGBUILD
+++ b/BioArchLinux/r-hrbrthemes/PKGBUILD
@@ -10,8 +10,6 @@ arch=(any)
 url="https://cran.r-project.org/package=$_pkgname"
 license=('MIT')
 depends=(
-  r-extrafont
-  r-gdtools
   r-ggplot2
   r-magrittr
   r-scales

--- a/BioArchLinux/r-hrbrthemes/lilac.yaml
+++ b/BioArchLinux/r-hrbrthemes/lilac.yaml
@@ -3,8 +3,6 @@ maintainers:
 - github: pekkarr
   email: pekkarr@protonmail.com
 repo_depends:
-- r-extrafont
-- r-gdtools
 - r-ggplot2
 - r-magrittr
 - r-scales


### PR DESCRIPTION
BioArchLinux is at 0.8.7-3; CRAN is at 0.9.3 (2026-04-20). The auto-update is stuck because 0.9.3 dropped `extrafont` and `gdtools` from `Imports`, so `r_pre_build` would fail with `Unnecessary dependency`.

Removed `r-extrafont` and `r-gdtools` from both `depends` (PKGBUILD) and `repo_depends` (lilac.yaml). Existing `optdepends` already match the new `Suggests`, and the `prepare()` sed still targets a line that exists in the 0.9.3 test file.

cc @pekkarr (maintainer)
