### PR TITLE
r-rsconnect r-snowflakeauth r-packrat r-pki: init pkgs

### DIFF
--- a/BioArchLinux/r-packrat/PKGBUILD
+++ b/BioArchLinux/r-packrat/PKGBUILD
@@ -1,0 +1,26 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=packrat
+_pkgver=0.9.3
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="A Dependency Management System for Projects and their R Package Dependencies"
+arch=(any)
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('GPL-2.0-only')
+depends=(
+  r
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('0fb56511d2cb19a94ac0a5e2633550df')
+b2sums=('197d4d46e77e7c655cbab627c9babc738c02a2ed6d317b2f460e163cb58d91e06a69b9b154faab4426fe995beee6e32e5031a446c184cfdbd69f636c15ad730b')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}

--- a/BioArchLinux/r-packrat/lilac.py
+++ b/BioArchLinux/r-packrat/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-packrat/lilac.yaml
+++ b/BioArchLinux/r-packrat/lilac.yaml
@@ -1,0 +1,10 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+update_on:
+  - source: rpkgs
+    pkgname: packrat
+    repo: cran
+    md5: true
+  - alias: r

--- a/BioArchLinux/r-pki/PKGBUILD
+++ b/BioArchLinux/r-pki/PKGBUILD
@@ -1,0 +1,28 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=PKI
+_pkgver=0.1-15
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Public Key Infrastucture for R Based on the X.509 Standard"
+arch=('x86_64')
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('GPL-2.0-only OR GPL-3.0-only')
+depends=(
+  openssl
+  r
+  r-base64enc
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('810291ef57ab2a2ca3237d0adb81a290')
+b2sums=('446cd53d30d5125f44f88a9005c7f13ecb41809c02bd28131a5395dd1e9b11d939d85231afcd837b6cbe782a2dd6fbe5809d402245fd53d7bd63bdd2f7a61770')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}

--- a/BioArchLinux/r-pki/lilac.py
+++ b/BioArchLinux/r-pki/lilac.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(
+        _G,
+        expect_license = "GPL-2 | GPL-3 | file LICENSE",
+        expect_systemrequirements = "OpenSSL library and headers (openssl-dev or\nsimilar)",
+    )
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-pki/lilac.yaml
+++ b/BioArchLinux/r-pki/lilac.yaml
@@ -1,0 +1,12 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-base64enc
+update_on:
+  - source: rpkgs
+    pkgname: PKI
+    repo: cran
+    md5: true
+  - alias: r

--- a/BioArchLinux/r-rsconnect/PKGBUILD
+++ b/BioArchLinux/r-rsconnect/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=rsconnect
+_pkgver=1.10.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Deploy Docs, Apps, and APIs to 'Posit Connect', 'shinyapps.io', and 'RPubs'"
+arch=(any)
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('GPL-2.0-only')
+depends=(
+  r
+  r-cli
+  r-curl
+  r-digest
+  r-httr2
+  r-jsonlite
+  r-lifecycle
+  r-openssl
+  r-packrat
+  r-pki
+  r-renv
+  r-rlang
+  r-rstudioapi
+  r-snowflakeauth
+  r-yaml
+)
+optdepends=(
+  r-biobase
+  r-biocmanager
+  r-foreign
+  r-knitr
+  r-mass
+  r-plumber
+  r-quarto
+  r-reticulate
+  r-rmarkdown
+  r-shiny
+  r-testthat
+  r-webfakes
+  r-withr
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('8a115a2342d9f41365f999af8211ce6e')
+b2sums=('c116b306c416069218a7accd605f7f42acd82ff4c91d9f0b701153cbaf7b8313251fbeb6937cc29e5155665d49c5baec996eb0081045181651f593a3b2cda8b4')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}

--- a/BioArchLinux/r-rsconnect/lilac.py
+++ b/BioArchLinux/r-rsconnect/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-rsconnect/lilac.yaml
+++ b/BioArchLinux/r-rsconnect/lilac.yaml
@@ -1,0 +1,25 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-cli
+  - r-curl
+  - r-digest
+  - r-httr2
+  - r-jsonlite
+  - r-lifecycle
+  - r-openssl
+  - r-packrat
+  - r-pki
+  - r-renv
+  - r-rlang
+  - r-rstudioapi
+  - r-snowflakeauth
+  - r-yaml
+update_on:
+  - source: rpkgs
+    pkgname: rsconnect
+    repo: cran
+    md5: true
+  - alias: r

--- a/BioArchLinux/r-snowflakeauth/PKGBUILD
+++ b/BioArchLinux/r-snowflakeauth/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=snowflakeauth
+_pkgver=0.2.2
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Authentication Helpers for 'Snowflake'"
+arch=(any)
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('MIT')
+depends=(
+  r
+  r-cli
+  r-curl
+  r-jose
+  r-jsonlite
+  r-openssl
+  r-rcpptoml
+  r-rlang
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('85d42d3cfd537082a9ad65719b762349')
+b2sums=('b97c68bfaee0b08de1e313276b3060a5142d6687fa73b29bd806b0bf90043d6d686b8b2b201834b24f6a279e88bb5f5bd74b4873e8b99a52c4f766854fd67e97')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}

--- a/BioArchLinux/r-snowflakeauth/lilac.py
+++ b/BioArchLinux/r-snowflakeauth/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-snowflakeauth/lilac.yaml
+++ b/BioArchLinux/r-snowflakeauth/lilac.yaml
@@ -1,0 +1,18 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-cli
+  - r-curl
+  - r-jose
+  - r-jsonlite
+  - r-openssl
+  - r-rcpptoml
+  - r-rlang
+update_on:
+  - source: rpkgs
+    pkgname: snowflakeauth
+    repo: cran
+    md5: true
+  - alias: r


### PR DESCRIPTION
Adds `r-rsconnect` 1.10.0 (deploy R Markdown/Shiny/APIs to Posit Connect, shinyapps.io, RPubs) and its three missing CRAN dependencies. All other Imports were already in BioArchLinux.

| Package | Version | License | Notes |
|---|---|---|---|
| `r-pki` | 0.1-15 | GPL-2 OR GPL-3 | X.509 PKI; NeedsCompilation: yes; needs openssl |
| `r-packrat` | 0.9.3 | GPL-2 | Dependency management; pure R |
| `r-snowflakeauth` | 0.2.2 | MIT | Snowflake auth helpers; pure R |
| `r-rsconnect` | 1.10.0 | GPL-2 | Posit Connect / shinyapps.io / RPubs deployment |

Verification:
- `makepkg --verifysource` for all four
- `makepkg -Cf --nodeps` for r-pki and r-packrat (built clean locally)
- `bash -n` for all four PKGBUILDs
- `python -m py_compile` for all four lilac.py files
- YAML parse check for all four lilac.yaml files
