### PR TITLE
Fix pre_build checks for r-pki, r-packrat, r-snowflakeauth

### DIFF
--- a/BioArchLinux/r-packrat/PKGBUILD
+++ b/BioArchLinux/r-packrat/PKGBUILD
@@ -12,6 +12,16 @@ license=('GPL-2.0-only')
 depends=(
   r
 )
+optdepends=(
+  r-devtools
+  r-httr
+  r-knitr
+  r-mockery
+  r-rmarkdown
+  r-testthat
+  r-webfakes
+  r-withr
+)
 source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 md5sums=('0fb56511d2cb19a94ac0a5e2633550df')
 b2sums=('197d4d46e77e7c655cbab627c9babc738c02a2ed6d317b2f460e163cb58d91e06a69b9b154faab4426fe995beee6e32e5031a446c184cfdbd69f636c15ad730b')

--- a/BioArchLinux/r-pki/lilac.py
+++ b/BioArchLinux/r-pki/lilac.py
@@ -10,7 +10,7 @@ def pre_build():
     r_pre_build(
         _G,
         expect_license = "GPL-2 | GPL-3 | file LICENSE",
-        expect_systemrequirements = "OpenSSL library and headers (openssl-dev or\nsimilar)",
+        expect_systemrequirements = "OpenSSL library and headers (openssl-dev or similar)",
     )
 
 def post_build():

--- a/BioArchLinux/r-snowflakeauth/PKGBUILD
+++ b/BioArchLinux/r-snowflakeauth/PKGBUILD
@@ -19,6 +19,12 @@ depends=(
   r-rcpptoml
   r-rlang
 )
+optdepends=(
+  r-httpuv
+  r-keyring
+  r-testthat
+  r-withr
+)
 source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
 md5sums=('85d42d3cfd537082a9ad65719b762349')
 b2sums=('b97c68bfaee0b08de1e313276b3060a5142d6687fa73b29bd806b0bf90043d6d686b8b2b201834b24f6a279e88bb5f5bd74b4873e8b99a52c4f766854fd67e97')


### PR DESCRIPTION
Three packages from #364 failed `r_pre_build` metadata checks on the build server. Fixes:

- **r-pki**: `expect_systemrequirements` had a literal newline (`openssl-dev or\nsimilar`); the DESCRIPTION parser joins continuation lines with a single space, so the check never matched. Joined to one line.
- **r-packrat**: added `optdepends` for all CRAN `Suggests` (r-devtools, r-httr, r-knitr, r-mockery, r-rmarkdown, r-testthat, r-webfakes, r-withr) — `check_optdepends` requires each non-default Suggests entry be listed.
- **r-snowflakeauth**: same — added `optdepends` (r-httpuv, r-keyring, r-testthat, r-withr).

These unblock r-rsconnect, which depends on all three.