### PR TITLE
r-sjstats r-ggeffects r-sjplot: init pkgs

### DIFF
--- a/BioArchLinux/r-ggeffects/PKGBUILD
+++ b/BioArchLinux/r-ggeffects/PKGBUILD
@@ -1,0 +1,103 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=ggeffects
+_pkgver=2.3.2
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Create Tidy Data Frames of Marginal Effects for 'ggplot' from Model Outputs"
+arch=(any)
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('MIT')
+depends=(
+  r
+  r-datawizard
+  r-insight
+  r-reformulas
+)
+optdepends=(
+  r-aer
+  r-afex
+  r-aod
+  r-bayestestr
+  r-betareg
+  r-brglm
+  r-brglm2
+  r-brms
+  r-broom
+  r-car
+  r-cardata
+  r-clubsandwich
+  r-dfidx
+  r-effects
+  r-effectsize
+  r-emmeans
+  r-fixest
+  r-gam
+  r-gamlss
+  r-gamm4
+  r-gee
+  r-geepack
+  r-ggplot2
+  r-ggrepel
+  r-glmmadaptive
+  r-glmmtmb
+  r-gridextra
+  r-gt
+  r-haven
+  r-htmltools
+  r-httr2
+  r-jsonlite
+  r-knitr
+  r-lme4
+  r-logistf
+  r-logitr
+  r-marginaleffects
+  r-mclogit
+  r-mcmcglmm
+  r-mice
+  r-mlogit
+  r-modelbased
+  r-mumin
+  r-nestedlogit
+  r-ordinal
+  r-parameters
+  r-parsnip
+  r-patchwork
+  r-plm
+  r-pscl
+  r-quantreg
+  r-rmarkdown
+  r-rms
+  r-robustbase
+  r-rstanarm
+  r-rstantools
+  r-sandwich
+  r-sdmtmb
+  r-see
+  r-sjlabelled
+  r-sjstats
+  r-speedglm
+  r-survey
+  r-testthat
+  r-tibble
+  r-tinytable
+  r-vdiffr
+  r-vgam
+  r-withr
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('8f532d73707e4827f07c50312e769bec')
+b2sums=('e08aef006871e7e36b1276fbcf3e43f86e39474f046bf78e044999b57fdf9025b675acdefbf4635a7e1a8e250757c29bdfb8b7ceae3bd9c5259f2b1376d6f885')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+
+  install -dm0755 "${pkgdir}/usr/share/licenses/${pkgname}"
+  ln -s "/usr/lib/R/library/${_pkgname}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}"
+}

--- a/BioArchLinux/r-ggeffects/lilac.py
+++ b/BioArchLinux/r-ggeffects/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-ggeffects/lilac.yaml
+++ b/BioArchLinux/r-ggeffects/lilac.yaml
@@ -1,0 +1,14 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-datawizard
+  - r-insight
+  - r-reformulas
+update_on:
+  - source: rpkgs
+    pkgname: ggeffects
+    repo: cran
+    md5: true
+  - alias: r

--- a/BioArchLinux/r-sjplot/PKGBUILD
+++ b/BioArchLinux/r-sjplot/PKGBUILD
@@ -1,0 +1,66 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=sjPlot
+_pkgver=2.9.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Data Visualization for Statistics in Social Science"
+arch=(any)
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('GPL-3.0-only')
+depends=(
+  r
+  r-bayestestr
+  r-datawizard
+  r-dplyr
+  r-ggeffects
+  r-ggplot2
+  r-insight
+  r-knitr
+  r-parameters
+  r-performance
+  r-purrr
+  r-rlang
+  r-scales
+  r-sjlabelled
+  r-sjmisc
+  r-sjstats
+  r-tidyr
+)
+optdepends=(
+  r-brms
+  r-car
+  r-clubsandwich
+  r-cowplot
+  r-effects
+  r-ggrepel
+  r-ggridges
+  r-glmmtmb
+  r-gparotation
+  r-gridextra
+  r-haven
+  r-httr
+  r-lme4
+  r-nfactors
+  r-pscl
+  r-psych
+  r-rmarkdown
+  r-rstanarm
+  r-sandwich
+  r-survey
+  r-testthat
+  r-tmb
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('72ec035d87d15757806e05ff9229ef3b')
+b2sums=('a1b326dc1c8bf3964ebe8fbe6bd077c651b01afba78e4b9ec50a74ac31715dd9c5a865117d94f2a86a12ab718123927e8fe8455c49de085747ea89f17f7db6bf')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}

--- a/BioArchLinux/r-sjplot/lilac.py
+++ b/BioArchLinux/r-sjplot/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-sjplot/lilac.yaml
+++ b/BioArchLinux/r-sjplot/lilac.yaml
@@ -1,0 +1,27 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-bayestestr
+  - r-datawizard
+  - r-dplyr
+  - r-ggeffects
+  - r-ggplot2
+  - r-insight
+  - r-knitr
+  - r-parameters
+  - r-performance
+  - r-purrr
+  - r-rlang
+  - r-scales
+  - r-sjlabelled
+  - r-sjmisc
+  - r-sjstats
+  - r-tidyr
+update_on:
+  - source: rpkgs
+    pkgname: sjPlot
+    repo: cran
+    md5: true
+  - alias: r

--- a/BioArchLinux/r-sjstats/PKGBUILD
+++ b/BioArchLinux/r-sjstats/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=sjstats
+_pkgver=0.19.1
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Collection of Convenient Functions for Common Statistical Computations"
+arch=(any)
+url="https://cran.r-project.org/package=${_pkgname}"
+license=('GPL-3.0-only')
+depends=(
+  r
+  r-datawizard
+  r-effectsize
+  r-insight
+  r-parameters
+  r-performance
+)
+optdepends=(
+  r-brms
+  r-car
+  r-coin
+  r-ggplot2
+  r-lme4
+  r-pscl
+  r-pwr
+  r-survey
+  r-testthat
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('de7f7afd46a99d8006fe3fb3310cdfec')
+b2sums=('e9b8f10ef871511b3c95724cb978cdbb2352376c59e5aa37910aa36709edaa217f496f12d89fa21d641e6dfbda45d9ca7156adcbbbc96242a617bc7d29f03eec')
+
+build() {
+  R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "${_pkgname}" "${pkgdir}/usr/lib/R/library"
+}

--- a/BioArchLinux/r-sjstats/lilac.py
+++ b/BioArchLinux/r-sjstats/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-sjstats/lilac.yaml
+++ b/BioArchLinux/r-sjstats/lilac.yaml
@@ -1,0 +1,16 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-datawizard
+  - r-effectsize
+  - r-insight
+  - r-parameters
+  - r-performance
+update_on:
+  - source: rpkgs
+    pkgname: sjstats
+    repo: cran
+    md5: true
+  - alias: r


### PR DESCRIPTION
Adds three CRAN packages so the `sjPlot`/`ggeffects` regression-visualization stack is available in the repo. One commit per package, in dependency order.

- **r-sjstats** 0.19.1 — collection of convenient functions for common statistical computations.
- **r-ggeffects** 2.3.2 — tidy data frames of marginal effects from model outputs (for ggplot).
- **r-sjplot** 2.9.0 — data visualization for statistics in social science. Depends on the two above.

Their entire transitive dependency tree (insight, datawizard, parameters, performance, bayestestR, effectsize, sjmisc, sjlabelled, dplyr, ggplot2, …) is already in the repo, so this is just the three leaf packages.

### Verification

For each package, locally:

- `python -m py_compile lilac.py` — OK
- `R CMD INSTALL` — installs cleanly (all three are `NeedsCompilation: no`, `arch=any`)
- `requireNamespace()` load test with deps resolved — all three load `TRUE`
- `depends`/`optdepends` generated directly from CRAN `Depends`/`Imports`/`Suggests`, with base/recommended packages (provided by `r`) excluded.

> Note: this is a multi-package PR with per-package commits — please **rebase-merge** (not squash) to keep them.
