### PR TITLE
r-zip: add 7zip to checkdepends for encryption tests

### DIFF
--- a/BioArchLinux/r-zip/PKGBUILD
+++ b/BioArchLinux/r-zip/PKGBUILD
@@ -19,6 +19,7 @@ makedepends=(
   r-cli
 )
 checkdepends=(
+  7zip
   r-curl
   r-testthat
   r-webfakes


### PR DESCRIPTION
Follow-up to #367. The 3.0.0 build compiles fine but `check()` fails 4 tests in `test-zip-encrypt.R`:

```
Error in seven_zip(): 7-Zip (7zz/7z) not available
[ FAIL 4 | WARN 0 | SKIP 5 | PASS 504 ]
```

zip 3.0.0 added WinZip-AES/ZipCrypto round-trip tests that shell out to the `7z`/`7zz` binary, which isn't in the clean build chroot. Adding `7zip` (provides `7z`) to `checkdepends` makes it available. It's a system package from `extra`, so no `lilac.yaml` change is needed.

Verified locally with `makepkg`: with 7zip present the full suite is **FAIL 0 | PASS 520 | SKIP 5**.