### PR TITLE
python-smart_open:revert and fix to 7.7.1 to ensure snakemake compati…

### DIFF
--- a/BioArchLinux/python-smart_open/PKGBUILD
+++ b/BioArchLinux/python-smart_open/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=python-smart_open
 _pkgname=smart_open
-pkgver=8.0.0
+pkgver=7.7.1
 pkgrel=1
 pkgdesc="Library for efficient streaming of very large files from/to S3, HDFS, WebHDFS, HTTP, or local (compressed) files"
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=('python-build' 'python-installer' 'python-wheel' 'python-setuptools
 provides=("python-smart-open")
 conflicts=("python-smart-open")
 source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/RaRe-Technologies/${_pkgname}/archive/v${pkgver}.tar.gz")
-sha512sums=('b2afed681eb8822beaa4415de7f3f263753b949051c20444ea76eec2ef737e785bbceeed6af7febee43825cbde477cfa9350b03a815aa821f1312aa5508fb306')
+sha256sums=('a43c9e75c10944a2b9cee93bc3775b00d586d3c89575bcce0e672932b00707f1')
 
 build() {
 	cd "${srcdir}/${_pkgname}-${pkgver}"

--- a/BioArchLinux/python-smart_open/lilac.yaml
+++ b/BioArchLinux/python-smart_open/lilac.yaml
@@ -2,15 +2,11 @@ maintainers:
 - github: kashyapchhatbar
   email: kashyap.cc@gmail.com
 
-pre_build_script: update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+pre_build_script: update_pkgver_and_pkgrel('7.7.1')
 
 post_build: git_pkgbuild_commit
 
 update_on:
-- source: github
-  github: RaRe-Technologies/smart_open
-  use_max_tag: true
-  prefix: v
 - source: manual
-  manual: 1
+  manual: 7.7.1 
 - alias: python


### PR DESCRIPTION
## Involved packages

 - python-smart_open

## Involved issue

snakemake can't be installed if python-smart_open>=8.0, hence this measure.

## Details
<!-- 
If you would like to continue to work with us, we will invite you as a member of this organization.
Fill the detials using x for what you've done. For example
- [x] Would like to continue to work with us
-->
- [x] Tested in the local machine (largest 16G RAM) and it is passed without any issue
- [x] Fix the Packages
  - [x] PKGBUILD
  - [x] lilac.yaml
- [x] Would like to continue to work with us

## Additional Note

I have less experience with lilac.yaml. Can you check before merging whether the config will ensure that version stays at 7.7.1? Thanks. 