### PR TITLE
r-quarto: init pkg

### DIFF
--- a/BioArchLinux/r-quarto/PKGBUILD
+++ b/BioArchLinux/r-quarto/PKGBUILD
@@ -1,0 +1,64 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=quarto
+_pkgver=1.5.1
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="R Interface to 'Quarto' Markdown Publishing System"
+arch=(any)
+url="https://github.com/quarto-dev/quarto-r"
+license=('MIT')
+depends=(
+  r-cli
+  r-fs
+  r-htmltools
+  r-jsonlite
+  r-later
+  r-lifecycle
+  r-processx
+  r-rlang
+  r-rmarkdown
+  r-rstudioapi
+  r-xfun
+  r-yaml
+)
+optdepends=(
+  'quarto-cli-bin: Quarto command line tool'
+  r-bslib
+  r-callr
+  r-curl
+  r-dplyr
+  r-flextable
+  r-ggiraph
+  r-ggplot2
+  r-gt
+  r-heatmaply
+  r-kableextra
+  r-knitr
+  r-palmerpenguins
+  r-patchwork
+  r-pkgload
+  r-plotly
+  r-rsconnect
+  r-testthat
+  r-thematic
+  r-tidyverse
+  r-tinytable
+  r-whoami
+  r-withr
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('399b5a595e22f090193a9169d5bd84db')
+b2sums=('a1819b98936662bc8cb8cf4f43032b3f251ac739cad28ae7cf65cb306d8bd1e4d5474efb992223d7518239aff3e7b078921c0c2a7a950fb2d9ffa0d881e393e9')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "${_pkgname}"
+}
+
+package() {
+  install -dm0755 "${pkgdir}/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/${_pkgname}" "${pkgdir}/usr/lib/R/library"
+  install -Dm644 "${_pkgname}/LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+}

--- a/BioArchLinux/r-quarto/lilac.py
+++ b/BioArchLinux/r-quarto/lilac.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(
+        _G,
+        expect_systemrequirements = "Quarto command line tool (<https://github.com/quarto-dev/quarto-cli>).",
+    )
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-quarto/lilac.yaml
+++ b/BioArchLinux/r-quarto/lilac.yaml
@@ -1,0 +1,23 @@
+build_prefix: extra-x86_64
+maintainers:
+  - github: bshor
+    email: boris@bshor.com
+repo_depends:
+  - r-cli
+  - r-fs
+  - r-htmltools
+  - r-jsonlite
+  - r-later
+  - r-lifecycle
+  - r-processx
+  - r-rlang
+  - r-rmarkdown
+  - r-rstudioapi
+  - r-xfun
+  - r-yaml
+update_on:
+  - source: rpkgs
+    pkgname: quarto
+    repo: cran
+    md5: true
+  - alias: r


### PR DESCRIPTION
Add `r-quarto`, the R interface to the Quarto Markdown publishing system.

Notes:

- CRAN version: `1.5.1`
- `NeedsCompilation: no`, so `arch=(any)`
- All CRAN runtime imports are present in BioArchLinux
- CRAN Suggests are listed in `optdepends`, including currently unpackaged
  `r-thematic` and `r-whoami`
- The CRAN `SystemRequirements` entry is handled with
  `expect_systemrequirements`
- The external Quarto CLI is listed as an optional runtime hint via
  `quarto-cli-bin`

Verification:

- `bash -n BioArchLinux/r-quarto/PKGBUILD`
- `python -m py_compile BioArchLinux/r-quarto/lilac.py`
- YAML parse check for `BioArchLinux/r-quarto/lilac.yaml`
- `git diff --check`
- `makepkg --verifysource`
- `makepkg -f`
