### PR TITLE
r-see r-easystats: init pkgs

### DIFF
--- a/BioArchLinux/r-easystats/PKGBUILD
+++ b/BioArchLinux/r-easystats/PKGBUILD
@@ -1,0 +1,62 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=easystats
+_pkgver=0.7.6
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Framework for Easy Statistical Modeling, Visualization, and Reporting"
+arch=(any)
+url="https://easystats.github.io/easystats/"
+license=('MIT')
+depends=(
+  r-bayestestr
+  r-correlation
+  r-datawizard
+  r-effectsize
+  r-insight
+  r-modelbased
+  r-parameters
+  r-performance
+  r-report
+  r-see
+)
+optdepends=(
+  r-callr
+  r-collapse
+  r-cranlogs
+  r-dharma
+  r-dt
+  r-flexdashboard
+  r-formula
+  r-ggplot2
+  r-glmmtmb
+  r-httr
+  r-jsonlite
+  r-knitr
+  r-marginaleffects
+  r-mockery
+  r-pak
+  r-patchwork
+  r-rmarkdown
+  r-scholar
+  r-testthat
+  r-withr
+  r-xml2
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('a4175a8ae25b8483b355ffd5faee6569')
+b2sums=('58edfeeb31d6d91c8976af0f034eb92f9971b0fb75b58709f40eb64732f64a113f5121c442f3db92730e9aeb5bafecb87bf1036395ec9a98bb42881f67458c3c')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+
+  install -d "$pkgdir/usr/share/licenses/$pkgname"
+  ln -s "/usr/lib/R/library/$_pkgname/LICENSE" "$pkgdir/usr/share/licenses/$pkgname"
+}

--- a/BioArchLinux/r-easystats/lilac.py
+++ b/BioArchLinux/r-easystats/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-easystats/lilac.yaml
+++ b/BioArchLinux/r-easystats/lilac.yaml
@@ -1,0 +1,21 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+repo_depends:
+- r-bayestestr
+- r-correlation
+- r-datawizard
+- r-effectsize
+- r-insight
+- r-modelbased
+- r-parameters
+- r-performance
+- r-report
+- r-see
+update_on:
+- source: rpkgs
+  pkgname: easystats
+  repo: cran
+  md5: true
+- alias: r

--- a/BioArchLinux/r-see/PKGBUILD
+++ b/BioArchLinux/r-see/PKGBUILD
@@ -1,0 +1,79 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=see
+_pkgver=0.14.1
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Model Visualisation Toolbox for 'easystats' and 'ggplot2'"
+arch=(any)
+url="https://easystats.github.io/see/"
+license=('MIT')
+depends=(
+  r-bayestestr
+  r-correlation
+  r-datawizard
+  r-effectsize
+  r-ggplot2
+  r-insight
+  r-modelbased
+  r-parameters
+  r-patchwork
+  r-performance
+)
+optdepends=(
+  r-bh
+  r-brms
+  r-collapse
+  r-curl
+  r-dharma
+  r-discovr
+  r-emmeans
+  r-factoextra
+  r-formula
+  r-ggdag
+  r-ggdist
+  r-ggraph
+  r-ggrepel
+  r-ggridges
+  r-ggside
+  r-glmmtmb
+  r-httr2
+  r-lavaan
+  r-lme4
+  r-logspline
+  r-marginaleffects
+  r-mclogit
+  r-mclust
+  r-merderiv
+  r-metafor
+  r-nbclust
+  r-nfactors
+  r-psych
+  r-qqplotr
+  r-randomforest
+  r-rcppeigen
+  r-rlang
+  r-rmarkdown
+  r-rstanarm
+  r-scales
+  r-testthat
+  r-tidygraph
+  r-vdiffr
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('83d19fbc097f3bcf199bafb26f030705')
+b2sums=('c6e9c28ee85f5324dc21130621354a07ec0a79d34d787bc5cbad19e0be4f973dfd31c324eb39be6310f03a05bec8bfae9013d0602a85754515a19be581989620')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+
+  install -d "$pkgdir/usr/share/licenses/$pkgname"
+  ln -s "/usr/lib/R/library/$_pkgname/LICENSE" "$pkgdir/usr/share/licenses/$pkgname"
+}

--- a/BioArchLinux/r-see/lilac.py
+++ b/BioArchLinux/r-see/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-see/lilac.yaml
+++ b/BioArchLinux/r-see/lilac.yaml
@@ -1,0 +1,21 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+repo_depends:
+- r-bayestestr
+- r-correlation
+- r-datawizard
+- r-effectsize
+- r-ggplot2
+- r-insight
+- r-modelbased
+- r-parameters
+- r-patchwork
+- r-performance
+update_on:
+- source: rpkgs
+  pkgname: see
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
Adds CRAN `see` 0.14.1 and `easystats` 0.7.6.

`see` provides plotting utilities for the easystats ecosystem and is the only missing runtime dependency needed by `easystats`. `easystats` is the meta-package for the easystats statistical modeling, visualization, and reporting ecosystem.

Notes:
- One commit per package.
- Runtime dependencies are listed in `repo_depends`.
- CRAN `Suggests` are represented in `optdepends`, excluding packages provided by Arch's `r` package.

Verification:
- `makepkg -f --verifysource` for `r-see`
- `makepkg -f --verifysource` for `r-easystats`
- `makepkg -fd` for `r-see`
- `R_LIBS=/tmp/easystats-r-lib:/home/boris/R/x86_64-pc-linux-gnu-library/4.6:/usr/lib/R/library makepkg -Cfd` for `r-easystats` after locally installing `report` and `see` into `/tmp/easystats-r-lib`
- `python -m py_compile BioArchLinux/r-see/lilac.py BioArchLinux/r-easystats/lilac.py`
- `git diff --check`