### PR TITLE
r-vitals r-ragnar: init pkgs

### DIFF
--- a/BioArchLinux/r-ragnar/PKGBUILD
+++ b/BioArchLinux/r-ragnar/PKGBUILD
@@ -1,0 +1,67 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=ragnar
+_pkgver=0.3.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Retrieval-Augmented Generation (RAG) Workflows"
+arch=(x86_64)
+url="https://ragnar.tidyverse.org/"
+license=('MIT')
+depends=(
+  r-blob
+  r-cli
+  r-commonmark
+  r-curl
+  r-dbi
+  r-dbplyr
+  r-dplyr
+  r-duckdb
+  r-glue
+  r-httr2
+  r-jsonlite
+  r-mirai
+  r-reticulate
+  r-rlang
+  r-rvest
+  r-s7
+  r-stringi
+  r-tidyr
+  r-vctrs
+  r-withr
+  r-xml2
+)
+optdepends=(
+  r-connectcreds
+  r-ellmer
+  r-gargle
+  r-jose
+  r-knitr
+  r-lifecycle
+  r-mcptools
+  r-openssl
+  r-pandoc
+  r-paws.common
+  r-rmarkdown
+  r-shiny
+  r-stringr
+  r-testthat
+  r-tibble
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('53df7d9518bdd2ab56d50f78a5e1bae8')
+b2sums=('713ad89609fcfccf7abc9b3b32270173cd3a192dbb7ed41737476d5fc8a34d25fde01a4884a98e388e15ef2fa0d2b8262526e454875a531f1b929767737a248e')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+
+  install -d "$pkgdir/usr/share/licenses/$pkgname"
+  ln -s "/usr/lib/R/library/$_pkgname/LICENSE" "$pkgdir/usr/share/licenses/$pkgname"
+}

--- a/BioArchLinux/r-ragnar/lilac.py
+++ b/BioArchLinux/r-ragnar/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-ragnar/lilac.yaml
+++ b/BioArchLinux/r-ragnar/lilac.yaml
@@ -1,0 +1,32 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+repo_depends:
+- r-blob
+- r-cli
+- r-commonmark
+- r-curl
+- r-dbi
+- r-dbplyr
+- r-dplyr
+- r-duckdb
+- r-glue
+- r-httr2
+- r-jsonlite
+- r-mirai
+- r-reticulate
+- r-rlang
+- r-rvest
+- r-s7
+- r-stringi
+- r-tidyr
+- r-vctrs
+- r-withr
+- r-xml2
+update_on:
+- source: rpkgs
+  pkgname: ragnar
+  repo: cran
+  md5: true
+- alias: r

--- a/BioArchLinux/r-vitals/PKGBUILD
+++ b/BioArchLinux/r-vitals/PKGBUILD
@@ -1,0 +1,54 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=vitals
+_pkgver=0.3.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Large Language Model Evaluation"
+arch=(any)
+url="https://vitals.tidyverse.org/"
+license=('MIT')
+depends=(
+  r-cli
+  r-dplyr
+  r-ellmer
+  r-glue
+  r-httpuv
+  r-httr2
+  r-jsonlite
+  r-purrr
+  r-r6
+  r-rlang
+  r-s7
+  r-tibble
+  r-tidyr
+  r-withr
+)
+optdepends=(
+  r-ggplot2
+  r-here
+  r-htmltools
+  r-knitr
+  r-magick
+  r-ordinal
+  r-rmarkdown
+  r-testthat
+  r-vcr
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('b7ab765940f6de11bb0f9df44f62c201')
+b2sums=('04dac0b3d7ede513fd572f894f3fe7b2760631a4deb64e13595b0df235e539f20f4b1628c904925f2e9a99b04a8df2c80c0f42e084142ecde22f1a65b3009edd')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+
+  install -d "$pkgdir/usr/share/licenses/$pkgname"
+  ln -s "/usr/lib/R/library/$_pkgname/LICENSE" "$pkgdir/usr/share/licenses/$pkgname"
+}

--- a/BioArchLinux/r-vitals/lilac.py
+++ b/BioArchLinux/r-vitals/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-vitals/lilac.yaml
+++ b/BioArchLinux/r-vitals/lilac.yaml
@@ -1,0 +1,25 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+repo_depends:
+- r-cli
+- r-dplyr
+- r-ellmer
+- r-glue
+- r-httpuv
+- r-httr2
+- r-jsonlite
+- r-purrr
+- r-r6
+- r-rlang
+- r-s7
+- r-tibble
+- r-tidyr
+- r-withr
+update_on:
+- source: rpkgs
+  pkgname: vitals
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
Adds `r-vitals`, a framework for evaluating large-language-model applications, and `r-ragnar`, which provides retrieval-augmented-generation workflows for LLMs.

Verification:

- `makepkg -f --verifysource` in both package directories
- `makepkg -f` in both package directories
- `python -m py_compile BioArchLinux/r-vitals/lilac.py BioArchLinux/r-ragnar/lilac.py`
- `git diff --check`
