### PR TITLE
r-rbenchmark: add Benchmarking Routine for R

### DIFF
--- a/BioArchLinux/r-rbenchmark/PKGBUILD
+++ b/BioArchLinux/r-rbenchmark/PKGBUILD
@@ -1,0 +1,27 @@
+# Maintainer: Christos Longros <chris.longros@gmail.com>
+
+_pkgname=rbenchmark
+_pkgver=1.0.1
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Benchmarking Routine for R"
+arch=(x86_64)
+url="https://cran.r-project.org/package=$_pkgname"
+license=('GPL-2.0-or-later')
+depends=(
+  r
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('2b8e858c31505499107ca0db3de54f70')
+b2sums=('fa890619c044bb421977ba3215237fabf7d618bc2c1e4f9e9f73b60829042f1eba714cc68da1b3d7548d50488ea262105ca0180f0192fe94304e97028e56dfcd')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+}

--- a/BioArchLinux/r-rbenchmark/lilac.py
+++ b/BioArchLinux/r-rbenchmark/lilac.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+
+def pre_build():
+    r_pre_build(_G)
+
+
+def post_build():
+    git_pkgbuild_commit()
+    update_aur_repo()

--- a/BioArchLinux/r-rbenchmark/lilac.yaml
+++ b/BioArchLinux/r-rbenchmark/lilac.yaml
@@ -1,0 +1,10 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: chrislongros
+  email: chris.longros@gmail.com
+update_on:
+- source: rpkgs
+  pkgname: rbenchmark
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
Adds r-rbenchmark (CRAN rbenchmark 1.0.1): a simple routine for benchmarking R code, wrapping system.time().