### PR TITLE
r-secretbase: add Cryptographic Hash Functions and Data Encoding

### DIFF
--- a/BioArchLinux/r-secretbase/PKGBUILD
+++ b/BioArchLinux/r-secretbase/PKGBUILD
@@ -1,0 +1,30 @@
+# Maintainer: Christos Longros <chris.longros@gmail.com>
+
+_pkgname=secretbase
+_pkgver=1.3.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Cryptographic Hash Functions and Data Encoding"
+arch=(x86_64)
+url="https://cran.r-project.org/package=$_pkgname"
+license=('MIT')
+depends=(
+  r
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('a563588d4e0d71e2aa92b2aeec56f046')
+b2sums=('a2a953390177af4c8843e18a0ab75e920a61302950b591590c5998f6f240152fe6b09f619571d709eccb76e38e4cd8976b733c78a1f0102799763e7e0b0d6404')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+
+  install -d "$pkgdir/usr/share/licenses/$pkgname"
+  ln -s "/usr/lib/R/library/$_pkgname/LICENSE" "$pkgdir/usr/share/licenses/$pkgname"
+}

--- a/BioArchLinux/r-secretbase/lilac.py
+++ b/BioArchLinux/r-secretbase/lilac.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+
+def pre_build():
+    r_pre_build(_G)
+
+
+def post_build():
+    git_pkgbuild_commit()
+    update_aur_repo()

--- a/BioArchLinux/r-secretbase/lilac.yaml
+++ b/BioArchLinux/r-secretbase/lilac.yaml
@@ -1,0 +1,10 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: chrislongros
+  email: chris.longros@gmail.com
+update_on:
+- source: rpkgs
+  pkgname: secretbase
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
Adds r-secretbase (CRAN secretbase 1.3.0): fast cryptographic hash functions (SHA-256/-3, BLAKE2/3, etc.) and data encoding, with no package dependencies. Also a required dependency for r-targets.