### PR TITLE
r-rbenchmark: fix arch

### DIFF
--- a/BioArchLinux/r-rbenchmark/PKGBUILD
+++ b/BioArchLinux/r-rbenchmark/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=r-${_pkgname,,}
 pkgver=${_pkgver//-/.}
 pkgrel=1
 pkgdesc="Benchmarking Routine for R"
-arch=(x86_64)
+arch=(any)
 url="https://cran.r-project.org/package=$_pkgname"
 license=('GPL-2.0-or-later')
 depends=(


### PR DESCRIPTION
arch=(any), not x86_64 (lilac failed with "Wrong arch, expected any").