### PR TITLE
r-simplermarkdown: add Simple Engine for Generating Reports using R

### DIFF
--- a/BioArchLinux/r-simplermarkdown/PKGBUILD
+++ b/BioArchLinux/r-simplermarkdown/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: Christos Longros <chris.longros@gmail.com>
+
+_pkgname=simplermarkdown
+_pkgver=0.0.6
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Simple Engine for Generating Reports using R"
+arch=(any)
+url="https://cran.r-project.org/package=$_pkgname"
+license=('GPL-3.0-or-later')
+depends=(
+  pandoc
+  r
+  r-rjson
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('a692f54b8cdb625a3472b8f82fe2bd42')
+b2sums=('e5a9b594f5f605fcfd8e9875269f7137464e022de43fb1e6ac50e9ba2e5b1addb9406a0a1146a57d8cc5388571c1d347eda2d2974d8657d39d10298b998811e7')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+}

--- a/BioArchLinux/r-simplermarkdown/lilac.py
+++ b/BioArchLinux/r-simplermarkdown/lilac.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+
+def pre_build():
+    r_pre_build(_G)
+
+
+def post_build():
+    git_pkgbuild_commit()
+    update_aur_repo()

--- a/BioArchLinux/r-simplermarkdown/lilac.yaml
+++ b/BioArchLinux/r-simplermarkdown/lilac.yaml
@@ -1,0 +1,12 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: chrislongros
+  email: chris.longros@gmail.com
+repo_depends:
+- r-rjson
+update_on:
+- source: rpkgs
+  pkgname: simplermarkdown
+  repo: cran
+  md5: true
+- alias: r


### PR DESCRIPTION
Adds `r-simplermarkdown` (CRAN 0.0.6, GPL-3.0-or-later).