### PR TITLE
r-simplermarkdown: fix SystemRequirements check

### DIFF
--- a/BioArchLinux/r-simplermarkdown/lilac.py
+++ b/BioArchLinux/r-simplermarkdown/lilac.py
@@ -8,7 +8,10 @@ from lilac_r_utils import r_pre_build
 
 
 def pre_build():
-    r_pre_build(_G)
+    r_pre_build(
+        _G,
+        expect_systemrequirements = "Pandoc (http://pandoc.org) needs to installed and available in the search path.",
+    )
 
 
 def post_build():


### PR DESCRIPTION
The first build failed in `pre_build`:

```
lilac_r_utils.CheckFailed: Check failed:
SystemRequirements have changed: Pandoc (http://pandoc.org) needs to installed and available in the search path.
```

`simplermarkdown` declares `SystemRequirements: Pandoc` in its DESCRIPTION, so `check_systemrequirements` needs it declared too via `expect_systemrequirements'