### PR TITLE
r-paletteer: add cli dependency and update to 1.7.0

### DIFF
--- a/BioArchLinux/r-paletteer/PKGBUILD
+++ b/BioArchLinux/r-paletteer/PKGBUILD
@@ -1,15 +1,16 @@
 # Maintainer: Pekka Ristola <pekkarr [at] protonmail [dot] com>
 
 _pkgname=paletteer
-_pkgver=1.6.0
+_pkgver=1.7.0
 pkgname=r-${_pkgname,,}
 pkgver=${_pkgver//-/.}
-pkgrel=3
+pkgrel=1
 pkgdesc="Comprehensive Collection of Color Palettes"
 arch=(any)
 url="https://cran.r-project.org/package=$_pkgname"
 license=('GPL-3.0-only')
 depends=(
+  r-cli
   r-prismatic
   r-rematch2
   r-rlang
@@ -43,8 +44,8 @@ optdepends=(
   r-viridislite
 )
 source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
-md5sums=('2149379a13391b97581b43dd87aa6fd0')
-b2sums=('aa265005b33047bb26c085ded2212bbd60d13bb5a4c9590c1e756226a23315e0e625564af420dc5606408bd0a585ecbf75f732f873a935ac34384f9d6d576f1d')
+md5sums=('59f9ff864c7a4f38d7a79c1719403eb9')
+b2sums=('f2a4439d465f65da44f008d63f60bd34bf243b5f7cc31c5f40aff4e7b65a9698fe465c7ce27185104297c99446d76c65de1c6749ba6f07ae57d9f54229e60f40')
 
 prepare() {
   # skip failing test

--- a/BioArchLinux/r-paletteer/lilac.yaml
+++ b/BioArchLinux/r-paletteer/lilac.yaml
@@ -3,6 +3,7 @@ maintainers:
 - github: pekkarr
   email: pekkarr@protonmail.com
 repo_depends:
+- r-cli
 - r-prismatic
 - r-rematch2
 - r-rlang


### PR DESCRIPTION
## Summary

paletteer provides a common interface to color palettes from many R packages.

- Update CRAN paletteer from 1.6.0 to 1.7.0 and refresh source checksums.
- Add the new cli import to runtime dependencies and Lilac repo_depends.
- Leave the existing check function, NOT_CRAN=true setting, and scico test skip unchanged.

## Verification

- `makepkg -f --verifysource`
- `R_LIBS_USER="$PWD/dependency/usr/lib/R/library" makepkg -f -d` on Arch Linux.
- 196 passing test expectations, zero failures, one existing scico skip, and two warnings for new poisonfrogs/rdune SVG snapshots.
- Separate namespace-load checks for all declared runtime/test dependencies and discrete/continuous palette smoke tests, including ggthemes::Blue.
- Python compilation, YAML parsing, and staged `git diff --check`.

The build used temporary unpacked BioArch test dependencies and locally built ggthemes 6.0.0 from commit 9eefe1cb4a, not a clean chroot. No packages were installed system-wide. The `-d` flag was needed because temporary R libraries are not registered with pacman.

## Review Note

The last actual [server test run](https://build.bioarchlinux.org/api/pkg/r-paletteer/log/1788048737) had 13 visual snapshot failures; its later attempt was blocked on ggthemes. Those visual failures did not reproduce in this local build. The ggthemes repair is now on master, but that does not prove it explains the earlier snapshot differences. No snapshots were accepted or patched, and no additional tests were disabled. Please verify the next clean build before merging; this PR is left open for review because the environment difference remains unresolved.
