### PR TITLE
r-knitr: quote dependency entries and update r-knitr

### DIFF
--- a/BioArchLinux/r-knitr/PKGBUILD
+++ b/BioArchLinux/r-knitr/PKGBUILD
@@ -6,10 +6,10 @@
 # Contributor: Alex Branham <branham@utexas.edu>
 
 _pkgname=knitr
-_pkgver=1.51
+_pkgver=1.52
 pkgname=r-${_pkgname,,}
 pkgver=${_pkgver//-/.}
-pkgrel=2
+pkgrel=1
 pkgdesc="A General-Purpose Package for Dynamic Report Generation in R"
 arch=(any)
 url="https://cran.r-project.org/package=$_pkgname"
@@ -34,7 +34,6 @@ optdepends=(
   r-juliacall
   r-litedown
   r-magick
-  r-markdown
   r-otel
   r-otelsdk
   r-png
@@ -56,8 +55,8 @@ optdepends=(
   r-webshot
 )
 source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
-md5sums=('79f32f24b572fe198baca8882d6aa87f')
-b2sums=('eb35a26242c198d8a0a280983258cef8be5252aa842918e003564db83f7f814f8bff12d3b6f322ba52026d7c2d46cb3ae648c8bccdcdf6e6860bccdb9d600ac1')
+md5sums=('0fc9f044e50fd86269f05b6067159bc6')
+b2sums=('cc0203ec1c129890cdc92d71a6e618d953f744f9a04a0ed6e9c7325ddd5e63081312f7987ef53bb7f6005ab0cb05e5be2e41f59a5fdf86fa272143e60e84bbbd')
 
 build() {
   mkdir build

--- a/lilac-extensions/lilac_r_utils.py
+++ b/lilac-extensions/lilac_r_utils.py
@@ -1,6 +1,7 @@
 from lilac2.const import PACMAN_DB_DIR
 from lilaclib import edit_file, run_protected
 import pyalpm
+import shlex
 import tarfile
 from types import SimpleNamespace
 
@@ -573,7 +574,7 @@ def r_apply_dependency_fixes(fixes: dict):
             print("depends=(")
             # Print all depends
             for dep in fixes['depends']:
-                print(f"{indent}{dep}")
+                print(f"{indent}{shlex.quote(dep)}")
             # Skip until we find the closing parenthesis
             continue
         elif stripped.startswith("makedepends=("):
@@ -583,7 +584,7 @@ def r_apply_dependency_fixes(fixes: dict):
             print("makedepends=(")
             # Print all makedepends
             for dep in fixes['makedepends']:
-                print(f"{indent}{dep}")
+                print(f"{indent}{shlex.quote(dep)}")
             continue
         elif stripped.startswith("optdepends=("):
             in_depends = False
@@ -592,7 +593,7 @@ def r_apply_dependency_fixes(fixes: dict):
             print("optdepends=(")
             # Print all optdepends
             for dep in fixes['optdepends']:
-                print(f"{indent}{dep}")
+                print(f"{indent}{shlex.quote(dep)}")
             continue
         
         # Check if we're exiting a dependency array

--- a/lilac-extensions/tests/test_dependency_quoting.py
+++ b/lilac-extensions/tests/test_dependency_quoting.py
@@ -1,0 +1,84 @@
+import contextlib
+import importlib.util
+import io
+from pathlib import Path
+import subprocess
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "lilac_r_utils", ROOT / "lilac-extensions/lilac_r_utils.py"
+)
+utils = importlib.util.module_from_spec(SPEC)
+# The writer needs no live Lilac service or pacman database.
+with patch.dict(sys.modules, {
+    "lilac2.const": types.SimpleNamespace(PACMAN_DB_DIR="/unused"),
+    "lilaclib": types.SimpleNamespace(edit_file=None, run_protected=None),
+    "pyalpm": types.ModuleType("pyalpm"),
+}):
+    SPEC.loader.exec_module(utils)
+
+
+class DependencyQuotingTests(unittest.TestCase):
+    template = "depends=(\n  old\n)\nmakedepends=(\n  old\n)\noptdepends=(\n  old\n)\n"
+
+    def rewrite(self, text, fixes):
+        output = io.StringIO()
+        with patch.object(utils, "edit_file", return_value=iter(text.splitlines())):
+            with contextlib.redirect_stdout(output):
+                utils.r_apply_dependency_fixes(fixes)
+        return output.getvalue()
+
+    def assert_roundtrip(self, text, fixes):
+        subprocess.run(["bash", "-n"], input=text, text=True, check=True)
+        for name, expected in fixes.items():
+            command = text + f'\nfor value in "${{{name}[@]}}"; do printf "%s\\0" "$value"; done\n'
+            result = subprocess.run(
+                ["bash", "--noprofile", "--norc"], input=command,
+                text=True, capture_output=True, check=True,
+            )
+            actual = result.stdout.split("\0")[:-1]
+            self.assertEqual(actual, expected)
+
+    def test_knitr_descriptions(self):
+        fixes = {"depends": ["r-xfun"], "makedepends": [], "optdepends": [
+            "pandoc: R Markdown v2 and reStructuredText support",
+            "rst2pdf: rst2pdf() support",
+        ]}
+        self.assert_roundtrip(self.rewrite(self.template, fixes), fixes)
+
+    def test_shell_metacharacters_in_all_arrays(self):
+        values = ["r-cli", "libfoo>=1.0", "tool: owner's helper", 'tool: "quoted"',
+                  "tool: $HOME", "tool: $(printf injected)", "tool: `printf injected`",
+                  "tool: semi;colon", "tool: back\\slash", "tool: * [abc]"]
+        fixes = {name: values for name in ("depends", "makedepends", "optdepends")}
+        self.assert_roundtrip(self.rewrite(self.template, fixes), fixes)
+
+    def test_empty_arrays_and_idempotence(self):
+        fixes = {"depends": ["r-cli"], "makedepends": [], "optdepends": []}
+        once = self.rewrite(self.template, fixes)
+        self.assertEqual(once, self.rewrite(once, fixes))
+        self.assertIn("  r-cli\n", once)
+        self.assert_roundtrip(once, fixes)
+
+    def test_real_knitr_recipe(self):
+        recipe = (ROOT / "BioArchLinux/r-knitr/PKGBUILD").read_text()
+        # Read dependency values with Bash, as the real updater does.
+        fixes = {}
+        for name in ("depends", "makedepends", "optdepends"):
+            command = recipe + f'\nfor value in "${{{name}[@]}}"; do printf "%s\\0" "$value"; done\n'
+            result = subprocess.run(["bash"], input=command, text=True,
+                                    capture_output=True, check=True)
+            fixes[name] = result.stdout.split("\0")[:-1]
+        rewritten = self.rewrite(recipe, fixes)
+        self.assert_roundtrip(rewritten, fixes)
+        self.assertIn("build() {", rewritten)
+        self.assertIn("package() {", rewritten)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

knitr generates reports by executing R code embedded in documents.

The R dependency auto-fixer writes parsed strings back into Bash arrays without quoting them. For knitr, this converts the existing quoted `rst2pdf: rst2pdf() support` optional-dependency description into invalid shell syntax. Merely quoting the PKGBUILD by hand cannot fix the next automatic rewrite.

- Quote rewritten depends, makedepends, and optdepends entries with standard-library `shlex.quote`; simple package names retain their current formatting.
- Add four regression tests covering knitr's descriptions, version constraints and shell metacharacters, exact Bash round trips, empty arrays, idempotence, and the real knitr recipe.
- Update knitr 1.51 to 1.52 and remove markdown from Suggests to match CRAN.

Two commits keep the shared writer repair separate from the package update. No changes to dependency selection, array-block parsing, or Lilac scheduling.

## Verification

- Before the fix, three of four regression tests failed, including the exact knitr parentheses error. All four passed afterward on Arch Linux: `python -m unittest discover -s lilac-extensions/tests -v`.
- Python compilation and staged `git diff --check` passed.
- On Arch Linux: `makepkg -f --verifysource` and `makepkg -f` passed for knitr 1.52-1 without skipping dependency checks.
- A separate smoke test loaded the newly built temporary library and verified inline R and code-chunk rendering.

The regression tests mock Lilac/pyalpm service imports and the edit-file iterator, but exercise the real writer and real Bash syntax/value parsing. This does not exercise the full live Lilac service. knitr's recipe has no check function; its full upstream suite was not run. No packages were installed system-wide.

## Review

Please review the shared writer change before merging. The motivating [knitr failure log](https://build.bioarchlinux.org/api/pkg/r-knitr/log/1788825771) reports invalid syntax on the unquoted rst2pdf entry. This PR is intentionally left open because the helper affects other R packages too.
