### PR TITLE
r-rdtools: add dependency for r-roxygen2 8.1.0

### DIFF
--- a/BioArchLinux/r-rdtools/PKGBUILD
+++ b/BioArchLinux/r-rdtools/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Boris Shor <boris@bshor.com>
+
+_pkgname=rdtools
+_pkgver=0.1.0
+pkgname=r-${_pkgname,,}
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Efficient Manipulation of 'Rd' Files and Help Topics"
+arch=(x86_64)
+url="https://cran.r-project.org/package=$_pkgname"
+license=('MIT')
+depends=(
+  r
+)
+checkdepends=(
+  r-testthat
+  r-withr
+)
+optdepends=(
+  r-testthat
+  r-withr
+)
+source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
+md5sums=('15243eafd24d97371d15f573530d9a12')
+b2sums=('1148248769b621ec2d7a7b145b13ae28433edb8abaaf28c7d5ab29ad2c2a6f837ced3cf0c8d960f5f3f8b82fcbfa66a6d1af7e7705352765f78498b941218191')
+
+build() {
+  mkdir build
+  R CMD INSTALL -l build "$_pkgname"
+}
+
+check() {
+  cd "$_pkgname/tests"
+  R_LIBS="$srcdir/build" Rscript --vanilla testthat.R
+}
+
+package() {
+  install -d "$pkgdir/usr/lib/R/library"
+  cp -a --no-preserve=ownership "build/$_pkgname" "$pkgdir/usr/lib/R/library"
+
+  install -d "$pkgdir/usr/share/licenses/$pkgname"
+  ln -s "/usr/lib/R/library/$_pkgname/LICENSE" "$pkgdir/usr/share/licenses/$pkgname"
+}

--- a/BioArchLinux/r-rdtools/lilac.py
+++ b/BioArchLinux/r-rdtools/lilac.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+from lilaclib import *
+
+import os
+import sys
+sys.path.append(os.path.normpath(f'{__file__}/../../../lilac-extensions'))
+from lilac_r_utils import r_pre_build
+
+def pre_build():
+    r_pre_build(_G)
+
+def post_build():
+    git_pkgbuild_commit()

--- a/BioArchLinux/r-rdtools/lilac.yaml
+++ b/BioArchLinux/r-rdtools/lilac.yaml
@@ -1,0 +1,13 @@
+build_prefix: extra-x86_64
+maintainers:
+- github: bshor
+  email: boris@bshor.com
+repo_makedepends:
+- r-testthat
+- r-withr
+update_on:
+- source: rpkgs
+  pkgname: rdtools
+  repo: cran
+  md5: true
+- alias: r

--- a/BioArchLinux/r-roxygen2/PKGBUILD
+++ b/BioArchLinux/r-roxygen2/PKGBUILD
@@ -5,41 +5,42 @@
 # Contributor: Alex Branham <branham@utexas.edu>
 
 _pkgname=roxygen2
-_pkgver=8.0.0
+_pkgver=8.1.0
 pkgname=r-${_pkgname,,}
-pkgver=8.0.0
+pkgver=8.1.0
 pkgrel=1
 pkgdesc='In-Line Documentation for R'
 arch=('x86_64')
 url="https://cran.r-project.org/package=${_pkgname}"
 license=('MIT')
 depends=(
-  r
   r-brew
   r-cli
   r-commonmark
-  r-cpp11
   r-desc
   r-knitr
+  r-lifecycle
   r-pkgload
-  r-purrr
   r-r6
+  r-rdtools
   r-rlang
-  r-stringi
-  r-stringr
   r-withr
   r-xml2
+)
+makedepends=(
+  r-cpp11
 )
 optdepends=(
   r-covr
   r-r.methodss3
   r-r.oo
   r-rmarkdown
+  r-s7
   r-testthat
   r-yaml
 )
 source=("https://cran.r-project.org/src/contrib/${_pkgname}_${_pkgver}.tar.gz")
-sha256sums=('75816bf3a25554f5752254b985b7242490b0fabe68a5ada335c340b820ba34e8')
+sha256sums=('6ee35d555ba8cfdbb0ab9c419e4f4af03e6a7acd8a0eaa77bc31fd50941fb691')
 
 build() {
   R CMD INSTALL ${_pkgname}_${_pkgver}.tar.gz -l "${srcdir}"

--- a/BioArchLinux/r-roxygen2/lilac.yaml
+++ b/BioArchLinux/r-roxygen2/lilac.yaml
@@ -9,12 +9,11 @@ repo_depends:
 - r-cpp11
 - r-desc
 - r-knitr
+- r-lifecycle
 - r-pkgload
-- r-purrr
 - r-r6
+- r-rdtools
 - r-rlang
-- r-stringi
-- r-stringr
 - r-withr
 - r-xml2
 update_on:


### PR DESCRIPTION
## Summary

rdtools provides cached lookup and manipulation of R documentation topics; roxygen2 generates help files and NAMESPACE declarations from inline comments.

- Add r-rdtools 0.1.0, maintained by Boris Shor <boris@bshor.com>, with its testthat suite enabled.
- Update r-roxygen2 from 8.0.0 to 8.1.0 and add its required rdtools and lifecycle imports.
- Move cpp11 from runtime dependencies to makedepends (LinkingTo only), retaining its Lilac repo_depends edge.
- Remove obsolete purrr/stringi/stringr runtime dependencies and add suggested S7, matching current CRAN metadata.

One commit per package. Existing roxygen2 maintainer and updater are unchanged; no upstream source patches or test-policy changes.

## Verification

- Source verification for both packages: `makepkg -f --verifysource`.
- rdtools: `makepkg -f` passed on Arch Linux; 85 test expectations passed, zero failures/warnings, two upstream CRAN-mode skips.
- roxygen2: `R_LIBS_USER=<temporary-rdtools-library> makepkg -f -d` passed against the newly built rdtools. Other declared dependencies were already present; the new dependency was not installed system-wide.
- End-to-end smoke test loaded both new versions and generated valid Rd and NAMESPACE files from a temporary package, including a markdown cross-package help link.
- Python compilation, YAML maintainer/dependency checks, and staged `git diff --check` passed.

These are local Arch builds, not clean-chroot builds. The existing roxygen2 recipe has no check function; its full upstream test suite was not run. No system packages were installed.

## Review

The current [roxygen2 failure](https://build.bioarchlinux.org/api/pkg/r-roxygen2/log/1786320776) reports that rdtools is unavailable. This PR adds that missing package and leaves the dependency-chain addition open for maintainer review.
